### PR TITLE
Fix local directory path for Telemt file uploads in telemt_manager.py

### DIFF
--- a/managers/telemt_manager.py
+++ b/managers/telemt_manager.py
@@ -140,7 +140,7 @@ docker compose version
         self._ensure_docker_compose()
             
         results.append("Uploading Telemt files...")
-        local_dir = os.path.join(os.path.dirname(__file__), 'protocol_telemt')
+        local_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'protocol_telemt')
         remote_dir = "/opt/amnezia/telemt"
         self.ssh.run_sudo_command(f"mkdir -p {remote_dir}")
         self.ssh.run_sudo_command(f"chmod 755 {remote_dir}")


### PR DESCRIPTION
# fix(telemt): correct local path to `protocol_telemt` on install

## Summary

Fixes the local path to Telemt assets (`config.toml`, `docker-compose.yml`, `Dockerfile`) when installing the protocol from the web panel.

## Problem

Telemt installation failed immediately with:

```
[Errno 2] No such file or directory: '.../managers/protocol_telemt/config.toml'
```

The `protocol_telemt` directory lives at the repository root, but `TelemtManager.install_protocol()` resolved paths relative to `managers/`, so files were missing before any SSH upload or Docker build.

## Solution

In `managers/telemt_manager.py`, build the path from the project root:

- **Before:** `os.path.join(os.path.dirname(__file__), 'protocol_telemt')`
- **After:** `os.path.join(os.path.dirname(os.path.dirname(__file__)), 'protocol_telemt')`

## Changed files

- `managers/telemt_manager.py` — one line in `install_protocol()`

## Short description

Fix incorrect `protocol_telemt` path: install looked under `managers/protocol_telemt` instead of the repo root, causing Telemt setup to fail with `ENOENT` on `config.toml`.
