### PR TITLE
Fix AWG 2.0: generate non-overlapping H-ranges instead of fixed values

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -66,8 +66,15 @@ def generate_psk():
 
 
 def generate_awg_params(use_ranges=False):
-    """Generate random AWG obfuscation parameters."""
+    """Generate random AWG obfuscation parameters.
+    
+    For AWG 2.0 (use_ranges=True): generates H1-H4 as non-overlapping
+    ranges (min-max) for dynamic packet signature. Each packet gets a
+    random value from its range, defeating static DPI signatures.
+    For legacy AWG (use_ranges=False): generates fixed single H values.
+    """
     import random
+
     jc = random.randint(1, 10)
     jmin = random.randint(5, 20)
     jmax = random.randint(jmin + 10, jmin + 50)
@@ -77,11 +84,22 @@ def generate_awg_params(use_ranges=False):
     s4 = random.randint(10, 50)
 
     if use_ranges:
-        # Standard AWG 2.0 headers. Use single large numbers.
-        h1 = str(random.randint(1000000000, 4294967295))
-        h2 = str(random.randint(1000000000, 4294967295))
-        h3 = str(random.randint(1000000000, 4294967295))
-        h4 = str(random.randint(1000000000, 4294967295))
+        # AWG 2.0: H1-H4 as non-overlapping ranges (min-max)
+        # Split [1B, 4.29B] into 4 equal zones, pick random sub-range in each
+        # Guarantees no intersections between H1-H4 per AWG 2.0 spec
+        def make_ranges(total_min=1000000000, total_max=4294967295):
+            zone_size = (total_max - total_min) // 4
+            result = []
+            for i in range(4):
+                z_start = total_min + i * zone_size
+                z_end = z_start + zone_size - 1
+                padding = min(100000, zone_size // 4)
+                a = random.randint(z_start + padding, z_end - padding)
+                b = random.randint(a + 1, z_end)
+                result.append(f"{a}-{b}")
+            return result
+        
+        h1, h2, h3, h4 = make_ranges()
     else:
         h1 = str(random.randint(100000000, 4294967295))
         h2 = str(random.randint(100000000, 4294967295))


### PR DESCRIPTION
## Problem

In AmneziaWG 2.0, the H1-H4 magic header parameters **must be ranges** (`min-max`) rather than fixed values. Additionally, these ranges **must not overlap** with each other — this is a strict requirement of the AWG 2.0 kernel module.

The current `generate_awg_params()` function generates **fixed single numbers** even for AWG/AWG2 protocols (`use_ranges=True`), producing configs like:

```
H1 = 3650788147
H2 = 2687430379
H3 = 3055099599
H4 = 3900344707
```

This is incorrect for AWG 2.0. The expected format is:

```
H1 = 1933801942-2007752054
H2 = 2027923565-2105380786
H3 = 2135300332-2135665690
H4 = 2138218437-2140915898
```

## Impact

Without this fix:
- AWG 2.0 connections use **static H signatures** that DPI can easily fingerprint
- The `use_ranges=True` parameter is effectively a no-op for H-values (only changes the minimum random value from 100M to 1B)
- Generated configs are **incompatible** with the AmneziaWG 2.0.1 Windows client which validates H-range format

## Solution

Changed `generate_awg_params()` to generate **non-overlapping ranges** for AWG 2.0:

- Split the full range `[1,000,000,000 — 4,294,967,295]` into **4 equal zones**
- Pick a random sub-range within each zone for H1-H4 respectively
- This guarantees no intersections between ranges by construction
- Legacy AWG (`use_ranges=False`) continues to use fixed single values (backward compatible)

### Example output after fix:
```
H1 = 1678446393-1744381949  (zone 1)
H2 = 2109153674-2273787742  (zone 2)
H3 = 2743842223-3258573181  (zone 3)
H4 = 4081043795-4289234493  (zone 4)
```

## Testing

- Verified that legacy AWG mode (`use_ranges=False`) still produces fixed H values
- Verified that AWG 2.0 mode (`use_ranges=True`) produces non-overlapping H-ranges
- Confirmed ranges do not intersect across 100+ test iterations
- Confirmed server and client configs both include the H-range format

## Related

- AWG 2.0 spec: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module
- Fixes #22 (potential DPI fingerprinting via static H values)