### PR TITLE
Fix peer IP allocation: fill subnet gaps, sort peers by IP, backup config

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -811,28 +811,78 @@ tail -f /dev/null
         return ips
 
     def _get_next_ip(self, protocol_type):
-        """Calculate the next available IP for a new client."""
+        """Return the first free IP in the subnet, filling gaps left by deleted clients.
+
+        The old implementation took the last IP in file order and incremented it,
+        which produced duplicate IPs when peers were not sorted by IP and never
+        reused addresses freed by deleted clients.
+        """
         used_ips = self._get_used_ips(protocol_type)
-        if not used_ips:
-            base = self._get_subnet_base(protocol_type)
-            parts = base.split('.')
-            parts[3] = '2'
-            return '.'.join(parts)
+        base = self._get_subnet_base(protocol_type)
+        parts = base.split('.')
+        prefix = '.'.join(parts[:3])
 
-        # Get the last used IP and increment
-        last_ip = used_ips[-1]
-        parts = last_ip.split('.')
-        last_octet = int(parts[3])
+        used_octets = set()
+        for ip in used_ips:
+            ip_parts = ip.split('.')
+            if len(ip_parts) != 4 or '.'.join(ip_parts[:3]) != prefix:
+                continue
+            try:
+                used_octets.add(int(ip_parts[3]))
+            except ValueError:
+                continue
 
-        if last_octet == 254:
-            next_octet = last_octet + 3
-        elif last_octet == 255:
-            next_octet = last_octet + 2
-        else:
-            next_octet = last_octet + 1
+        for octet in range(2, 255):
+            if octet not in used_octets:
+                parts[3] = str(octet)
+                return '.'.join(parts)
 
-        parts[3] = str(next_octet)
-        return '.'.join(parts)
+        raise RuntimeError("No free IP addresses left in the subnet")
+
+    @staticmethod
+    def _peer_block_ip(block):
+        """Sort key for a [Peer] config block: its first AllowedIPs IPv4 address."""
+        match = re.search(r'AllowedIPs\s*=\s*(\d+)\.(\d+)\.(\d+)\.(\d+)', block)
+        if match:
+            return tuple(int(match.group(i)) for i in range(1, 5))
+        return (255, 255, 255, 255)
+
+    def _insert_peer_sorted(self, protocol_type, peer_section):
+        """Insert a new [Peer] section into the server config keeping peers sorted by IP.
+
+        Creates a timestamped backup of the config inside the container before
+        overwriting it, then rewrites the file with all [Peer] sections ordered
+        by their AllowedIPs address.
+        """
+        container_name = self._container_name(protocol_type)
+        config_path = self._resolve_config_path(protocol_type)
+
+        config = self._get_server_config(protocol_type)
+
+        # Backup current config inside the container before modifying it
+        ts = __import__('datetime').datetime.now().strftime('%Y%m%d_%H%M%S')
+        self.ssh.run_sudo_command(
+            f"docker exec -i {container_name} cp {config_path} {config_path}.bak.{ts}"
+        )
+
+        head, _, rest = config.partition('[Peer]')
+        blocks = []
+        if rest:
+            for chunk in rest.split('[Peer]'):
+                chunk = chunk.strip()
+                if chunk:
+                    blocks.append('[Peer]\n' + chunk)
+
+        blocks.append(peer_section.strip())
+        blocks.sort(key=self._peer_block_ip)
+
+        new_config = head.rstrip('\n') + '\n\n' + '\n\n'.join(blocks) + '\n'
+
+        self.ssh.upload_file(new_config, "/tmp/_amnz_add_peer.conf")
+        self.ssh.run_sudo_command(
+            f"docker cp /tmp/_amnz_add_peer.conf {container_name}:{config_path}"
+        )
+        self.ssh.run_command("rm -f /tmp/_amnz_add_peer.conf")
 
     def _extract_ipv4(self, value):
         """Extract the first IPv4 address from AllowedIPs/clientIp-like values."""
@@ -1012,11 +1062,8 @@ PresharedKey = {psk}
 AllowedIPs = {client_ip}/32
 
 """
-        # Append peer to server config
-        escaped_peer = peer_section.replace("'", "'\\''")
-        self.ssh.run_sudo_command(
-            f"docker exec -i {container_name} bash -c 'echo \"{escaped_peer}\" >> {config_path}'"
-        )
+        # Insert peer into server config, keeping peers sorted by IP (with backup)
+        self._insert_peer_sorted(protocol_type, peer_section)
 
         # Sync config without restart
         self.ssh.run_sudo_command(

--- a/managers/wireguard_manager.py
+++ b/managers/wireguard_manager.py
@@ -426,22 +426,75 @@ tail -f /dev/null
         return ips
 
     def _get_next_ip(self):
-        """Calculate the next available IP for a new client."""
-        used_ips = self._get_used_ips()
-        if not used_ips:
-            base = WG_DEFAULTS['subnet_address']
-            parts = base.split('.')
-            parts[3] = '2'
-            return '.'.join(parts)
+        """Return the first free IP in the subnet, filling gaps left by deleted clients.
 
-        last_ip = used_ips[-1]
-        parts = last_ip.split('.')
-        last_octet = int(parts[3])
-        next_octet = last_octet + 1
-        if next_octet > 254:
-            next_octet = 2
-        parts[3] = str(next_octet)
-        return '.'.join(parts)
+        The old implementation took the last IP in file order and incremented it,
+        which produced duplicate IPs when peers were not sorted by IP and never
+        reused addresses freed by deleted clients.
+        """
+        used_ips = self._get_used_ips()
+        base = WG_DEFAULTS['subnet_address']
+        parts = base.split('.')
+        prefix = '.'.join(parts[:3])
+
+        used_octets = set()
+        for ip in used_ips:
+            ip_parts = ip.split('.')
+            if len(ip_parts) != 4 or '.'.join(ip_parts[:3]) != prefix:
+                continue
+            try:
+                used_octets.add(int(ip_parts[3]))
+            except ValueError:
+                continue
+
+        for octet in range(2, 255):
+            if octet not in used_octets:
+                parts[3] = str(octet)
+                return '.'.join(parts)
+
+        raise RuntimeError("No free IP addresses left in the subnet")
+
+    @staticmethod
+    def _peer_block_ip(block):
+        """Sort key for a [Peer] config block: its first AllowedIPs IPv4 address."""
+        match = re.search(r'AllowedIPs\s*=\s*(\d+)\.(\d+)\.(\d+)\.(\d+)', block)
+        if match:
+            return tuple(int(match.group(i)) for i in range(1, 5))
+        return (255, 255, 255, 255)
+
+    def _insert_peer_sorted(self, peer_section):
+        """Insert a new [Peer] section into the server config keeping peers sorted by IP.
+
+        Creates a timestamped backup of the config inside the container before
+        overwriting it, then rewrites the file with all [Peer] sections ordered
+        by their AllowedIPs address.
+        """
+        config = self._get_server_config()
+
+        # Backup current config inside the container before modifying it
+        ts = __import__('datetime').datetime.now().strftime('%Y%m%d_%H%M%S')
+        self.ssh.run_sudo_command(
+            f"docker exec -i {self.CONTAINER_NAME} cp {self.CONFIG_PATH} {self.CONFIG_PATH}.bak.{ts}"
+        )
+
+        head, _, rest = config.partition('[Peer]')
+        blocks = []
+        if rest:
+            for chunk in rest.split('[Peer]'):
+                chunk = chunk.strip()
+                if chunk:
+                    blocks.append('[Peer]\n' + chunk)
+
+        blocks.append(peer_section.strip())
+        blocks.sort(key=self._peer_block_ip)
+
+        new_config = head.rstrip('\n') + '\n\n' + '\n\n'.join(blocks) + '\n'
+
+        self.ssh.upload_file(new_config, "/tmp/_wg_add_peer.conf")
+        self.ssh.run_sudo_command(
+            f"docker cp /tmp/_wg_add_peer.conf {self.CONTAINER_NAME}:{self.CONFIG_PATH}"
+        )
+        self.ssh.run_command("rm -f /tmp/_wg_add_peer.conf")
 
     def _parse_peers_from_config(self):
         """Parse [Peer] sections from WireGuard server config."""
@@ -593,7 +646,6 @@ tail -f /dev/null
             
         mtu = WG_DEFAULTS['mtu']
 
-        # Append peer to server config
         peer_section = f"""
 [Peer]
 PublicKey = {client_pub_key}
@@ -601,10 +653,8 @@ PresharedKey = {psk}
 AllowedIPs = {client_ip}/32
 
 """
-        escaped_peer = peer_section.replace("'", "'\\''")
-        self.ssh.run_sudo_command(
-            f"docker exec -i {self.CONTAINER_NAME} bash -c 'echo \"{escaped_peer}\" >> {self.CONFIG_PATH}'"
-        )
+        # Insert peer into server config, keeping peers sorted by IP (with backup)
+        self._insert_peer_sorted(peer_section)
 
         # Sync config without restart
         self.ssh.run_sudo_command(


### PR DESCRIPTION
## Problem
`_get_next_ip()` in `managers/awg_manager.py` and `managers/wireguard_manager.py` took the **last IP in config file order** and incremented it. This caused:

1. **Duplicate IPs** — if peers in `awg0.conf`/`wg0.conf` are not sorted ascending (after manual edits, migrations, deletions), the next client could get an `AllowedIPs` already used by another peer. WireGuard then applies only the last matching `[Peer]`, breaking one of the clients.
2. **Gaps never reused** — deleting a client (e.g. `10.8.1.5`) left the address unused forever; new clients kept getting higher IPs.
3. **Octet overflow** — `awg_manager` produced invalid octets (`254 → 257`, `255 → 257`).

## Fix
- `_get_next_ip()` now collects all used addresses into a set and returns the **first free IP** in the subnet (`.2`–`.254`), filling gaps. Raises a clear error when the subnet is exhausted.
- New peers are no longer blindly appended (`>> config`). A new helper `_insert_peer_sorted()` rewrites the config with all `[Peer]` sections **sorted by AllowedIPs**, keeping the `[Interface]` header intact.
- Before overwriting, a **timestamped backup** (`awg0.conf.bak.YYYYMMDD_HHMMSS`) is created inside the container.

## Notes
- Existing duplicate peers are not touched — this only fixes allocation for new clients.
- Tested locally: config reassembly preserves the interface section and sorts peers numerically by IP.