### PR TITLE
fix(xray): make hot user add work with Xray-core v26 runtime API

### DIFF
--- a/managers/xray_manager.py
+++ b/managers/xray_manager.py
@@ -400,9 +400,12 @@ ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]
         tag = self._get_vless_inbound_tag(config)
         if not tag:
             return False
+        _ib = self._get_vless_inbound(config) or {}
         payload = {
             "inbounds": [{
                 "tag": tag,
+                "port": _ib.get('port', 443),
+                "listen": "0.0.0.0",
                 "protocol": "vless",
                 "settings": {
                     "clients": [client],
@@ -411,7 +414,7 @@ ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]
             }]
         }
         ok, message = self._run_xray_api_json('adu', payload)
-        if not ok:
+        if not ok or 'Added 0 user' in (message or ''):
             logger.warning(f"Xray API add user failed: {message}")
             return False
         return True


### PR DESCRIPTION
## Problem

Adding/toggling Xray clients via the panel appears to succeed, but the new client cannot actually connect — the running Xray process rejects it with `proxy/vless/encoding: invalid request user id`. A manual `docker restart amnezia-xray` is required before the client works.

## Root cause

The panel installs Xray-core **v26.3.27** (see the Dockerfile in `install_protocol`). In v26, `xray api adu` builds a *full inbound config* from the provided payload. The payload sent by `_xray_api_add_user` contains only `tag` + `settings`, so `adu` fails to build the config:

```
processing inbound: proxy
failed to build config: infra/conf: Listen on AnyIP but no Port(s) set in InboundDetour.
Added 0 user(s) in total.
```

Critically, the command still exits with code **0**, so the panel treats the hot-add as successful (it only checks the exit code). The client ends up in `server.json` but never reaches the runtime → `invalid request user id` until the next container restart.

## Fix

Two minimal changes in `_xray_api_add_user`:

1. Include the VLESS inbound's `port` and `listen` in the `adu` payload so Xray v26 can build the inbound config. Verified live against Xray-core 26.3.27:
   ```
   processing inbound: proxy
   add user: 11111111-2222-3333-4444-555555555555
   result: ok
   Added 1 user(s) in total.
   ```
2. Treat `Added 0 user(s)` in the command output as a failure, so if the runtime API misbehaves again the caller falls back to the existing "restart the container manually" error path instead of silently reporting success.

Tested on a live server: after the patch, newly created panel clients connect immediately, without restarting the container.