### PR TITLE
fix(ui): перепутанные бейджи ↓ скачано / ↑ отдано у пиров

### DIFF
--- a/templates/server.html
+++ b/templates/server.html
@@ -2040,8 +2040,10 @@
                     if (userData.expiry) metaHtml += `<span class="badge" style="font-size:0.65rem;">⌛ ${formatDate(userData.expiry)}</span>`;
                 } else {
                     if (handshake) metaHtml += `<span>🤝 ${handshake}</span>`;
-                    if (received) metaHtml += `<span class="traffic-badge traffic-down">↓ ${received}</span>`;
-                    if (sent) metaHtml += `<span class="traffic-badge traffic-up">↑ ${sent}</span>`;
+                    // awg show reports transfer from the SERVER perspective:
+                    // "received" = client upload, "sent" = client download.
+                    if (sent) metaHtml += `<span class="traffic-badge traffic-down">↓ ${sent}</span>`;
+                    if (received) metaHtml += `<span class="traffic-badge traffic-up">↑ ${received}</span>`;
                 }
 
                 if (!enabled) metaHtml += `<span class="badge badge-danger" style="font-size:0.65rem">${_('stop')}</span>`;


### PR DESCRIPTION
## Проблема

`awg show` / `wg show` отдаёт счётчики трафика пира **с точки зрения сервера**:

- `received` — байты, которые клиент **отправил** (upload клиента)
- `sent` — байты, которые клиент **скачал** (download клиента)

В `templates/server.html` бейджи выводились наоборот: под стрелкой ↓ (скачано) показывался `received`, а под ↑ (отдано) — `sent`. В результате у активно качающего пользователя большая цифра отображалась как «отдано».

## Исправление

Поменял местами бейджи (с точки зрения клиента):

- ↓ download = `dataSent` (сервер отправил → клиент скачал)
- ↑ upload = `dataReceived` (сервер принял → клиент отдал)

Изменение — 2 строки в `templates/server.html` + комментарий. Бэкенд не тронут.