### PR TITLE
Publish Docker images to GHCR from the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,16 @@ on:
     branches: [ "main" ]
     tags:
       - 'v*'
+  # TEMP(debug): run on pull requests to validate the workflow before review.
+  # Remove this trigger together with the other TEMP(debug) blocks below.
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: write
+
+env:
+  IMAGE_NAME: amnezia-panel
 
 jobs:
   build:
@@ -76,6 +82,102 @@ jobs:
       with:
         name: binaries-${{ runner.os }}
         path: dist/*
+
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      # TEMP(debug): pull_request runs from a fork get a read-only GITHUB_TOKEN,
+      # so images are only pushed for same-repository events.
+      PUSH_IMAGE: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            dockerfile: Dockerfile
+            suffix: ''
+            # The panel runs on both x86_64 and ARM64 servers.
+            platforms: linux/amd64,linux/arm64
+          - variant: warp
+            dockerfile: Dockerfile.warp
+            suffix: '-warp'
+            # cloudflare-warp is installed via apt, which is slow under QEMU.
+            # linux/arm64 can be added here — the Cloudflare repo ships it.
+            platforms: linux/amd64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Resolve image name
+      id: image
+      run: |
+        owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        echo "name=ghcr.io/${owner}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+    - name: Log in to GHCR
+      if: env.PUSH_IMAGE == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ steps.image.outputs.name }}
+        flavor: |
+          latest=false
+          ${{ matrix.suffix != '' && format('suffix={0},onlatest=true', matrix.suffix) || '' }}
+        # TEMP(debug): `type=ref,event=pr` adds a pr-<number> tag for PR runs.
+        tags: |
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha,format=short
+        labels: |
+          org.opencontainers.image.title=Amnezia Web Panel${{ matrix.suffix }}
+          org.opencontainers.image.description=Web panel for managing Amnezia VPN servers
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ matrix.dockerfile }}
+        platforms: ${{ matrix.platforms }}
+        push: ${{ env.PUSH_IMAGE == 'true' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=${{ matrix.variant }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+
+    - name: Job summary
+      run: |
+        {
+          echo "### Docker: ${{ matrix.variant }} (${{ matrix.dockerfile }})"
+          echo
+          echo "Platforms: \`${{ matrix.platforms }}\`, pushed: \`${{ env.PUSH_IMAGE }}\`"
+          echo
+          echo '```'
+          echo "${{ steps.meta.outputs.tags }}"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
 
   release:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches: [ "main" ]
     tags:
       - 'v*'
-  # TEMP(debug): run on pull requests to validate the workflow before review.
-  # Remove this trigger together with the other TEMP(debug) blocks below.
-  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -90,11 +87,6 @@ jobs:
       contents: read
       packages: write
 
-    env:
-      # TEMP(debug): pull_request runs from a fork get a read-only GITHUB_TOKEN,
-      # so images are only pushed for same-repository events.
-      PUSH_IMAGE: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +113,6 @@ jobs:
         echo "name=ghcr.io/${owner}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
     - name: Log in to GHCR
-      if: env.PUSH_IMAGE == 'true'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -142,11 +133,9 @@ jobs:
         flavor: |
           latest=false
           ${{ matrix.suffix != '' && format('suffix={0},onlatest=true', matrix.suffix) || '' }}
-        # TEMP(debug): `type=ref,event=pr` adds a pr-<number> tag for PR runs.
         tags: |
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
           type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
@@ -161,7 +150,7 @@ jobs:
         context: .
         file: ${{ matrix.dockerfile }}
         platforms: ${{ matrix.platforms }}
-        push: ${{ env.PUSH_IMAGE == 'true' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha,scope=${{ matrix.variant }}
@@ -172,7 +161,7 @@ jobs:
         {
           echo "### Docker: ${{ matrix.variant }} (${{ matrix.dockerfile }})"
           echo
-          echo "Platforms: \`${{ matrix.platforms }}\`, pushed: \`${{ env.PUSH_IMAGE }}\`"
+          echo "Platforms: \`${{ matrix.platforms }}\`"
           echo
           echo '```'
           echo "${{ steps.meta.outputs.tags }}"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ Mac
 
 https://hub.docker.com/r/prvtpro/amnezia-panel
 
+Images are also published to GitHub Container Registry on every push to `main` and on every `v*` tag:
+
+```bash
+# Panel
+docker pull ghcr.io/prvtpro/amnezia-panel:latest
+
+# Panel with Cloudflare WARP inside the container
+docker pull ghcr.io/prvtpro/amnezia-panel:latest-warp
+```
+
 
 ### Initial Login
 *   **Username**: `admin`


### PR DESCRIPTION
Closes #90.

Adds a `docker` job to the existing `Build Binaries` workflow so images are built and published to GitHub Container Registry automatically, with the whole pipeline visible in Actions.

## What it does

Builds both image variants with Buildx and pushes them to GHCR on pushes to `main` and on `v*` tags:

| Dockerfile | Image | Platforms |
| --- | --- | --- |
| `Dockerfile` | `ghcr.io/<owner>/amnezia-panel` | `linux/amd64`, `linux/arm64` |
| `Dockerfile.warp` | same image, `-warp` tag suffix | `linux/amd64` |

The image name is derived from `github.repository_owner`, so the workflow works unchanged both here and in any fork. `linux/arm64` for the WARP variant is left out only because `cloudflare-warp` is installed via apt and that is slow under QEMU — the Cloudflare repo ships arm64, so it is a one-line change whenever it is wanted.

Tags follow the scheme already used on Docker Hub, so nothing surprising for existing users:

* `latest` — on `main` and on `v*` tags
* `<branch>` — e.g. `main`
* `v1.6.0`, `1.6`, `1` — from semver tags
* `sha-<short>`
* the WARP variant gets all of the above with a `-warp` suffix

OCI labels are set from `docker/metadata-action`, including `org.opencontainers.image.source`, so the package is linked to the repository. GHA build cache is enabled with a separate scope per variant.

## What it does not touch

* **Docker Hub publishing is unchanged** — no credentials, no login step, nothing removed. This PR only adds GHCR as an additional registry, so the migration can happen at your pace.
* `docker-compose.yml` still points at `prvtpro/amnezia-panel:latest`.
* The `build` (PyInstaller) and `release` jobs are untouched — the workflow diff is additive only.

Image signing (mentioned in #90) is intentionally left out of this PR to keep it small; it can be added on top with `cosign` once the images are being published.

## Verification

Validated on a pull request in my fork, with a temporary `pull_request` trigger that was removed before opening this PR — [run 32826316065](https://github.com/helldweller/Amnezia-Web-Panel/actions/runs/32826316065): all five jobs green, `release` correctly skipped.

* Multi-arch manifest actually pushed — the build log shows both `[linux/amd64 …]` and `[linux/arm64 …]` stages and `exporting manifest list sha256:a51ec518…`.
* Docker job wall time: ~2 min per variant, arm64 under QEMU included (all dependencies resolve to prebuilt wheels on Python 3.14, nothing is compiled from source).
* `actionlint` v1.7.7 — clean.

## Note

The first successful run creates the GHCR package as **private**. It has to be switched to public once in the package settings for `docker pull` to work without authentication.