### PR TITLE
Bump CURRENT_VERSION to v1.6.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ else:
     application_path = os.path.dirname(__file__)
 
 DATA_FILE = os.path.join(application_path, 'data.json')
-CURRENT_VERSION = "v1.5.0"
+CURRENT_VERSION = "v1.6.0"
 BIN_DIR = os.environ.get('TUNNEL_BIN_DIR', os.path.join(application_path, 'bin'))
 TUNNEL_STATE_FILE = os.environ.get('TUNNEL_STATE_FILE', os.path.join(application_path, 'tunnels_state.json'))
 


### PR DESCRIPTION
Fixes #93.

The v1.6.0 release commit (dec0e90) touched `app.py` but left `CURRENT_VERSION` at `v1.5.0`, so `main` and the `v1.6.0` tag both still report 1.5.0.

It is not only the badge on the settings page. `templates/settings.html` compares the constant with the `tag_name` of the latest GitHub release:

```js
const latestVersion = data.tag_name;             // v1.6.0
const currentVersion = '{{ current_version }}';  // v1.5.0
if (latestVersion !== currentVersion && latestVersion) { /* Update available */ }
```

So a panel that is already on 1.6.0 permanently advertises "Update available: v1.6.0" — the banner can never be cleared by updating.

This PR is the one-line bump. Worth considering separately: this has happened before — the tag `v1.4.1` also shipped with the constant still at `v1.4.0` — so deriving the version from the tag at build time, or from a `VERSION` file the release process has to touch, would remove the failure mode instead of resetting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)