### PR TITLE
fix(awg3): use compatibility H1-H4 = 1,2,3,4 per official docs (Header Protection mode)

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -132,6 +132,16 @@ def generate_awg_params(use_ranges=False, awg3=False):
             return result
         
         h1, h2, h3, h4 = make_ranges()
+    elif awg3:
+        # AWG 3.1: the official docs prescribe the compatibility values
+        # 1,2,3,4 when HeaderProtection is enabled - the custom-header
+        # mechanism is OFF then and Header Protection (ChaCha20 with the
+        # random per-server HeaderProtectionKey) hides the message type.
+        # This is exactly what the native AmneziaVPN client generates.
+        # Ranged H1-H4 with RandomTrailers=on are actively harmful:
+        # transport packets get misclassified as handshakes and die at
+        # CheckMAC1 (amneziawg-go#186, kernel-module#226).
+        h1, h2, h3, h4 = '1', '2', '3', '4'
     else:
         h1 = str(random.randint(100000000, 4294967295))
         h2 = str(random.randint(100000000, 4294967295))
@@ -457,12 +467,11 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         if awg_params is None:
             base_proto = self._base_protocol(protocol_type)
             awg_params = generate_awg_params(
-                # Ranged H1-H4 ("min-max") are valid for AWG 2.0, but with AWG 3.1
-            # features (HeaderProtectionKey etc.) current clients fail to
-            # authenticate packets ("invalid mac1" flood, <1 Mbit/s). Until
-            # clients catch up, use fixed random magic headers for AWG 3.1.
-            # See https://github.com/amnezia-vpn/amnezia-client/issues/3073
-            use_ranges=(base_proto in (self.AWG, self.AWG2)),
+                # AWG 2.0: ranged H1-H4 ("min-max"). AWG 3.1: fixed 1,2,3,4
+                # per the official docs (custom headers off, Header
+                # Protection hides the message type) - same as the native
+                # AmneziaVPN client generates.
+                use_ranges=(base_proto in (self.AWG, self.AWG2)),
                 awg3=(base_proto == self.AWG3),
             )
 

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -457,7 +457,12 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         if awg_params is None:
             base_proto = self._base_protocol(protocol_type)
             awg_params = generate_awg_params(
-                use_ranges=(base_proto in (self.AWG, self.AWG2, self.AWG3)),
+                # Ranged H1-H4 ("min-max") are valid for AWG 2.0, but with AWG 3.1
+            # features (HeaderProtectionKey etc.) current clients fail to
+            # authenticate packets ("invalid mac1" flood, <1 Mbit/s). Until
+            # clients catch up, use fixed random magic headers for AWG 3.1.
+            # See https://github.com/amnezia-vpn/amnezia-client/issues/3073
+            use_ranges=(base_proto in (self.AWG, self.AWG2)),
                 awg3=(base_proto == self.AWG3),
             )
 


### PR DESCRIPTION
## Problem

The panel generates H1–H4 as wide random ranges (hundreds of millions of values wide). With `RandomTrailers = on` — which AWG 3.1 configs enable — the packet classifier's size check is relaxed, transport packets get admitted into the handshake branches, and any packet whose 4 bytes at the branch offset fall inside the H range is killed at `CheckMAC1` («Received packet with invalid mac1» flood, throughput below 1 Mbit/s).

Root cause documented upstream: `amnezia-vpn/amneziawg-go#186` and `amnezia-vpn/amneziawg-linux-kernel-module#226` (per-branch loss probability ≈ range width / 2³²; measured 25% loss with production-width ranges, up to 75%+).

## Fix

**Updated after the official docs were amended** (https://docs.amnezia.org/ru/documentation/amnezia-wg/): for AWG 3.1 with Header Protection enabled the documentation prescribes the compatibility values `H1=1, H2=2, H3=3, H4=4`. In this mode the custom-header mechanism is **off** and Header Protection (ChaCha20 with the random per-server `HeaderProtectionKey`) hides the message type instead. This is exactly what the native AmneziaVPN client generates — the previously questioned hardcode in their templates is the documented behaviour, not a bug.

So for AWG 3.1 the panel now generates `H1–H4 = 1,2,3,4` + random `HeaderProtectionKey` + random `S1–S4`. Config uniqueness across servers is preserved (HP key, junk sizes, port are random); packet loss is zero because the H ranges have width 1 and equal the real WireGuard message types.

AWG 2.0 keeps non-overlapping ranged H1–H4 (valid for 2.0, no RandomTrailers there). Legacy AWG keeps fixed random values.

## Testing

`py_compile` clean; generator verified for all three modes (AWG3 → `1,2,3,4`; AWG2 → `min-max` ranges; legacy → fixed random). Live check on a real server: an AWG 3.1 instance with wide ranged H showed thousands of `Received packet with invalid mac1` and <1 Mbit/s; with fixed values full link speed restored instantly.