### PR TITLE
fix(ui): live speed/online indicators lost in #88 squash merge

### DIFF
--- a/templates/server.html
+++ b/templates/server.html
@@ -2077,11 +2077,16 @@
                     if (userData.quota) metaHtml += `<span class="badge" style="font-size:0.65rem;">Quota: ${formatBytes(userData.quota)}</span>`;
                     if (userData.expiry) metaHtml += `<span class="badge" style="font-size:0.65rem;">⌛ ${formatDate(userData.expiry)}</span>`;
                 } else {
-                    if (handshake) metaHtml += `<span>🤝 ${handshake}</span>`;
+                    const hsSec = parseHandshakeAgo(handshake);
+                    const isOnline = hsSec !== null && hsSec < 180;
+                    if (handshake) metaHtml += `<span class="meta-handshake${isOnline ? ' meta-online' : ''}">🤝 ${formatHandshakeCompact(handshake)}</span>`;
                     // awg show reports transfer from the SERVER perspective:
                     // "received" = client upload, "sent" = client download.
                     if (sent) metaHtml += `<span class="traffic-badge traffic-down">↓ ${sent}</span>`;
                     if (received) metaHtml += `<span class="traffic-badge traffic-up">↑ ${received}</span>`;
+                    const rates = computeRates(client.clientId, userData);
+                    if (rates) metaHtml += `<span class="traffic-badge speed-badge${rates.active ? ' speed-active' : ''}">↓${formatBytes(Math.round(rates.rx))}/s ↑${formatBytes(Math.round(rates.tx))}/s</span>`;
+                    if (isOnline) client._online = true;
                 }
 
                 if (!enabled) metaHtml += `<span class="badge badge-danger" style="font-size:0.65rem">${_('stop')}</span>`;

--- a/templates/server.html
+++ b/templates/server.html
@@ -2038,6 +2038,16 @@
             return;
         }
 
+        // Skip poll re-renders while the rename editor is open — a full innerHTML
+        // rebuild would destroy the input mid-typing
+        if (isPoll && document.querySelector('#connectionsListInner .rename-editor')) {
+            clearTimeout(window.connPollTimer);
+            if (document.getElementById('connectionsSection').style.display !== 'none') {
+                window.connPollTimer = setTimeout(function() { loadConnections(true); }, 5000);
+            }
+            return;
+        }
+
         if (window.connLoading) return; // don't stack overlapping polls
         window.connLoading = true;
         if (!isPoll) loading.style.display = ''; // silent refresh on polls


### PR DESCRIPTION
## Проблема

При squash-мерже #88 в `main` попали хелперы (`parseHandshakeAgo`, `formatHandshakeCompact`, `computeRates`) и CSS (`.meta-online`, `.speed-badge`, `.avatar-online`), но **цикл рендера их не вызывает**: `_online = true` не выставляется нигде, бейдж скорости не создаётся, handshake показывается длинной строкой.

Итог: пульсирующей точки онлайна и живой скорости в v1.6.0 нет, хотя весь код для них лежит мёртвым грузом.

## Решение

Возвращаю вызовы в цикл рендера — ровно то, что было в оригинальном #88:

- `🤝` в компактном виде (`2h 29m ago`) с классом `meta-online` при handshake < 3 мин;
- `client._online = true` → зелёная пульсирующая точка на аватаре;
- бейдж `↓X/s ↑Y/s` из дельт счётчиков между опросами.