### PR TITLE
feat(awg): per-peer connection flood warnings (P2P/torrent detection)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3235,6 +3235,27 @@ async def api_edit_connection(request: Request, server_id: int, req: EditConnect
         return JSONResponse({'error': str(e)}, status_code=500)
 
 
+@app.post('/api/servers/{server_id}/connections/clear_warnings', tags=["Connections"])
+async def api_clear_conn_warnings(request: Request, server_id: int, req: ConnectionActionRequest):
+    """Clear recorded connection-flood (torrent) warnings for one peer."""
+    if not _check_admin(request):
+        return JSONResponse({'error': 'Forbidden'}, status_code=403)
+    try:
+        data = load_data()
+        if server_id >= len(data['servers']):
+            return JSONResponse({'error': 'Server not found'}, status_code=404)
+        server = data['servers'][server_id]
+        ssh = get_ssh(server)
+        ssh.connect()
+        manager = get_protocol_manager(ssh, req.protocol)
+        result = _manager_call(manager, 'clear_conn_warnings', req.protocol, req.client_id) or {}
+        ssh.disconnect()
+        return result
+    except Exception as e:
+        logger.exception("Error clearing connection warnings")
+        return JSONResponse({'error': str(e)}, status_code=500)
+
+
 @app.post('/api/servers/{server_id}/connections/rename', tags=["Connections"])
 async def api_rename_connection(request: Request, server_id: int, req: RenameConnectionRequest):
     if not _check_admin(request):

--- a/app.py
+++ b/app.py
@@ -1680,7 +1680,7 @@ class TunnelStartRequest(BaseModel):
 # Each round is one cheap SSH roundtrip per AWG instance (a compact per-IP
 # conntrack summary), so detection works 24/7 without anyone watching the UI
 # and the 6s UI refresh only reads the small snapshot files.
-CONN_MONITOR_INTERVAL = 60
+CONN_MONITOR_INTERVAL = 600
 
 
 def _conn_monitor_loop():

--- a/app.py
+++ b/app.py
@@ -1676,8 +1676,49 @@ class TunnelStartRequest(BaseModel):
 
 # ======================== Startup ========================
 
+# Interval (seconds) between background connection-flood collection rounds.
+# Each round is one cheap SSH roundtrip per AWG instance (a compact per-IP
+# conntrack summary), so detection works 24/7 without anyone watching the UI
+# and the 6s UI refresh only reads the small snapshot files.
+CONN_MONITOR_INTERVAL = 60
+
+
+def _conn_monitor_loop():
+    from managers.awg_manager import AWGManager
+    while True:
+        try:
+            data = load_data()
+            for server in data.get('servers', []):
+                protocols = server.get('protocols', {}) or {}
+                for proto in list(protocols):
+                    if protocol_base(proto) not in ('awg', 'awg2', 'awg3'):
+                        continue
+                    try:
+                        AWGManager(get_ssh(server)).collect_conn_stats(proto)
+                    except Exception as e:
+                        logger.warning(
+                            f"conn monitor: {server.get('host')} {proto}: {e}")
+        except Exception as e:
+            logger.warning(f"conn monitor loop: {e}")
+        time.sleep(CONN_MONITOR_INTERVAL)
+
+
+_conn_monitor_started = False
+
+
+def _start_conn_monitor():
+    global _conn_monitor_started
+    if _conn_monitor_started:
+        return
+    _conn_monitor_started = True
+    threading.Thread(target=_conn_monitor_loop, daemon=True,
+                     name='conn-monitor').start()
+    logger.info(f"Connection-flood monitor started (every {CONN_MONITOR_INTERVAL}s)")
+
+
 @app.on_event("startup")
 async def startup():
+    _start_conn_monitor()
     data = load_data()
     changed = False
     if not data.get('users'):

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -13,8 +13,10 @@ import os
 import secrets
 import struct
 import hashlib
+import ipaddress
 import logging
 import re
+import time
 from base64 import b64encode, b64decode
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from cryptography.hazmat.primitives import serialization
@@ -30,8 +32,7 @@ AWG_DEFAULTS = {
     'subnet_ip': '10.8.1.1',
     # IPv6 ULA subnet used for dual-stack tunnels (NAT66, no provider prefix needed)
     'subnet_ipv6_ip': 'fd42:8:1::1',
-    'subnet_ipv6_cidr': '64',
-    'dns1': '1.1.1.1',
+    'subnet_ipv6_cidr': '64',    'dns1': '1.1.1.1',
     'dns2': '1.0.0.1',
     # AWG obfuscation parameters
     'junk_packet_count': '3',
@@ -71,6 +72,11 @@ AWG3_CONFIG_KEYS = tuple(config_key for _, config_key in AWG3_PARAM_MAP)
 # checks in netlink.c. Below that `awg setconf` fails with a bare
 # "Invalid argument": the explanation only goes to net_dbg_ratelimited.
 AWG3_MIN_JUNK_SIZE = 12
+
+# Connection flood monitoring (P2P/torrent detection)
+CONN_WARN_THRESHOLD = 600    # simultaneous connections per peer that trigger a warning
+CONN_WARN_COOLDOWN = 3600    # min seconds between two recorded warnings for the same peer
+CONN_WARN_MAX_EVENTS = 5     # how many recent warnings are kept per peer
 
 
 def generate_wg_keypair():
@@ -1155,6 +1161,28 @@ tail -f /dev/null
         except Exception as e:
             logger.warning(f'get_clients: failed to parse conf peers: {e}')
 
+        # Connection flood monitoring: count conntrack entries per peer IP
+        # and attach recent warnings (P2P/torrent detection).
+        try:
+            conn_counts = self._count_connections_by_ip(protocol_type)
+            conn_warnings = (self._update_conn_warnings(protocol_type, conn_counts)
+                             if conn_counts else self._load_conn_warnings(protocol_type))
+            for client in clients_table:
+                user_data = client.get('userData', {})
+                ip = user_data.get('clientIp', '')
+                if not ip:
+                    m = re.search(r'(\d+\.\d+\.\d+\.\d+)', user_data.get('allowedIps', '') or '')
+                    ip = m.group(1) if m else ''
+                if not ip:
+                    continue
+                user_data['clientIp'] = ip
+                user_data['connCount'] = conn_counts.get(ip, 0)
+                if ip in conn_warnings:
+                    user_data['connWarnings'] = conn_warnings[ip]
+                client['userData'] = user_data
+        except Exception as e:
+            logger.warning(f'get_clients: conn monitoring failed: {e}')
+
         return clients_table
 
     def _parse_bytes(self, size_str):
@@ -1167,6 +1195,94 @@ tail -f /dev/null
             return int(val * units.get(unit, 1))
         except Exception:
             return 0
+
+    # ---- Connection flood monitoring (P2P/torrent detection) ----
+
+    def _conn_warnings_path(self):
+        """Path inside container, next to clientsTable (persisted via volume)."""
+        return '/opt/amnezia/awg/conn_warnings.json'
+
+    def _count_connections_by_ip(self, protocol_type):
+        """Count conntrack entries per peer IP on the host.
+
+        Reads /proc/net/nf_conntrack on the host (no extra packages needed)
+        and counts entries whose ORIGINAL source IP belongs to the instance
+        subnet. Returns {ip: count}; empty dict if conntrack is unavailable.
+        """
+        try:
+            subnet_ip = self._get_subnet_ip(protocol_type)
+            cidr = int(self._get_subnet_cidr(protocol_type))
+            network = ipaddress.ip_network(f'{subnet_ip}/{cidr}', strict=False)
+        except Exception:
+            return {}
+
+        out, err, code = self.ssh.run_sudo_command(
+            "head -c 8000000 /proc/net/nf_conntrack 2>/dev/null"
+        )
+        if code != 0 or not out.strip():
+            return {}
+
+        counts = {}
+        for line in out.split('\n'):
+            # First src= on the line is the original (initiator) tuple
+            m = re.search(r'\bsrc=(\d+\.\d+\.\d+\.\d+)', line)
+            if not m:
+                continue
+            ip = m.group(1)
+            try:
+                if ipaddress.ip_address(ip) in network:
+                    counts[ip] = counts.get(ip, 0) + 1
+            except ValueError:
+                continue
+        return counts
+
+    def _load_conn_warnings(self, protocol_type):
+        """Load recorded warnings {ip: [{ts, count}, ...]} from the container."""
+        container_name = self._container_name(protocol_type)
+        out, err, code = self.ssh.run_sudo_command(
+            f"docker exec -i {container_name} cat {self._conn_warnings_path()} 2>/dev/null"
+        )
+        if code != 0 or not out.strip():
+            return {}
+        try:
+            data = json.loads(out)
+            return data if isinstance(data, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+
+    def _save_conn_warnings(self, protocol_type, warnings):
+        """Persist warnings into the container (same pattern as clientsTable)."""
+        container_name = self._container_name(protocol_type)
+        self.ssh.upload_file(json.dumps(warnings), "/tmp/_amnz_connwarn.json")
+        self.ssh.run_sudo_command(
+            f"docker cp /tmp/_amnz_connwarn.json {container_name}:{self._conn_warnings_path()}"
+        )
+        self.ssh.run_command("rm -f /tmp/_amnz_connwarn.json")
+
+    def _update_conn_warnings(self, protocol_type, counts):
+        """Record a warning for every peer above CONN_WARN_THRESHOLD.
+
+        At most one warning per peer per CONN_WARN_COOLDOWN seconds; only the
+        last CONN_WARN_MAX_EVENTS are kept. Returns {ip: [{ts, count}, ...]}.
+        """
+        warnings = self._load_conn_warnings(protocol_type)
+        now = int(time.time())
+        changed = False
+        for ip, count in counts.items():
+            if count < CONN_WARN_THRESHOLD:
+                continue
+            events = warnings.get(ip, [])
+            if events and now - int(events[-1].get('ts', 0)) < CONN_WARN_COOLDOWN:
+                continue
+            events.append({'ts': now, 'count': count})
+            warnings[ip] = events[-CONN_WARN_MAX_EVENTS:]
+            changed = True
+        if changed:
+            try:
+                self._save_conn_warnings(protocol_type, warnings)
+            except Exception as e:
+                logger.warning(f'failed to save conn warnings: {e}')
+        return warnings
 
     def _wg_show(self, protocol_type):
         """Run 'wg show all' and parse output."""

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1203,11 +1203,13 @@ tail -f /dev/null
         return '/opt/amnezia/awg/conn_warnings.json'
 
     def _count_connections_by_ip(self, protocol_type):
-        """Count conntrack entries per peer IP on the host.
+        """Count conntrack entries per peer IP.
 
-        Reads /proc/net/nf_conntrack on the host (no extra packages needed)
-        and counts entries whose ORIGINAL source IP belongs to the instance
-        subnet. Returns {ip: count}; empty dict if conntrack is unavailable.
+        Reads /proc/net/nf_conntrack INSIDE the instance container (NAT for
+        the VPN subnet happens in the container's netns, so the host table
+        only shows the container's own IP) and counts entries whose ORIGINAL
+        source IP belongs to the instance subnet.
+        Returns {ip: count}; empty dict if conntrack is unavailable.
         """
         try:
             subnet_ip = self._get_subnet_ip(protocol_type)
@@ -1217,7 +1219,8 @@ tail -f /dev/null
             return {}
 
         out, err, code = self.ssh.run_sudo_command(
-            "head -c 8000000 /proc/net/nf_conntrack 2>/dev/null"
+            f"docker exec -i {self._container_name(protocol_type)} "
+            "sh -c 'head -c 8000000 /proc/net/nf_conntrack 2>/dev/null'"
         )
         if code != 0 or not out.strip():
             return {}

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1223,10 +1223,15 @@ tail -f /dev/null
             return {}
 
         container = self._container_name(protocol_type)
-        awk_prog = ("awk '{for(i=1;i<=NF;i++) if($i~/^src=/){sub(/^src=/,\"\",$i); "
-                    "print $i; break}}' /proc/net/nf_conntrack 2>/dev/null | sort | uniq -c")
+        # tr/grep/cut pipeline instead of awk: the command travels through a
+        # double remote shell (ssh + sh -c "..."), which mangles awk's $i
+        # fields no matter how they are escaped. Each conntrack line has two
+        # src= tokens (peer + external); the subnet filter below keeps only
+        # peer IPs, so counts match the awk version.
+        count_cmd = ("tr ' ' '\\n' < /proc/net/nf_conntrack 2>/dev/null "
+                     "| grep '^src=' | cut -d= -f2 | sort | uniq -c")
         out, err, code = self.ssh.run_sudo_command(
-            f'docker exec -i {container} sh -c "{awk_prog}"'
+            f'docker exec -i {container} sh -c "{count_cmd}"'
         )
         if code != 0 or not out.strip():
             return {}

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1287,6 +1287,25 @@ tail -f /dev/null
                 logger.warning(f'failed to save conn warnings: {e}')
         return warnings
 
+    def clear_conn_warnings(self, protocol_type, client_id):
+        """Clear all recorded connection-flood warnings for one peer."""
+        clients_table = self._get_clients_table(protocol_type)
+        client = next((c for c in clients_table if c.get('clientId') == client_id), None)
+        ip = None
+        if client:
+            ud = client.get('userData', {}) or {}
+            ip = ud.get('clientIp')
+            if not ip:
+                m = re.search(r'(\d+\.\d+\.\d+\.\d+)', ud.get('allowedIps', '') or '')
+                ip = m.group(1) if m else None
+        if not ip:
+            raise RuntimeError('Client IP not found')
+        warnings = self._load_conn_warnings(protocol_type)
+        if ip in warnings:
+            warnings.pop(ip, None)
+            self._save_conn_warnings(protocol_type, warnings)
+        return {'status': 'success', 'cleared_ip': ip}
+
     def _wg_show(self, protocol_type):
         """Run 'wg show all' and parse output."""
         container_name = self._container_name(protocol_type)

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1161,12 +1161,15 @@ tail -f /dev/null
         except Exception as e:
             logger.warning(f'get_clients: failed to parse conf peers: {e}')
 
-        # Connection flood monitoring: count conntrack entries per peer IP
-        # and attach recent warnings (P2P/torrent detection).
+        # Connection flood monitoring: attach the latest snapshot written by
+        # the background collector (collect_conn_stats). Only if the snapshot
+        # does not exist yet (fresh install / right after upgrade) fall back
+        # to a one-off live count so the UI is not empty for the first minute.
         try:
-            conn_counts = self._count_connections_by_ip(protocol_type)
-            conn_warnings = (self._update_conn_warnings(protocol_type, conn_counts)
-                             if conn_counts else self._load_conn_warnings(protocol_type))
+            conn_counts = self._load_conn_counts(protocol_type)
+            if not conn_counts:
+                conn_counts = self._count_connections_by_ip(protocol_type)
+            conn_warnings = self._load_conn_warnings(protocol_type)
             for client in clients_table:
                 user_data = client.get('userData', {})
                 ip = user_data.get('clientIp', '')
@@ -1205,10 +1208,11 @@ tail -f /dev/null
     def _count_connections_by_ip(self, protocol_type):
         """Count conntrack entries per peer IP.
 
-        Reads /proc/net/nf_conntrack INSIDE the instance container (NAT for
-        the VPN subnet happens in the container's netns, so the host table
-        only shows the container's own IP) and counts entries whose ORIGINAL
-        source IP belongs to the instance subnet.
+        Aggregates /proc/net/nf_conntrack INSIDE the instance container
+        (NAT for the VPN subnet happens in the container's netns, so the
+        host table only shows the container's own IP) and transfers only
+        the compact "count ip" summary instead of the multi-megabyte raw
+        table.
         Returns {ip: count}; empty dict if conntrack is unavailable.
         """
         try:
@@ -1218,26 +1222,72 @@ tail -f /dev/null
         except Exception:
             return {}
 
+        container = self._container_name(protocol_type)
+        awk_prog = ("awk '{for(i=1;i<=NF;i++) if($i~/^src=/){sub(/^src=/,\"\",$i); "
+                    "print $i; break}}' /proc/net/nf_conntrack 2>/dev/null | sort | uniq -c")
         out, err, code = self.ssh.run_sudo_command(
-            f"docker exec -i {self._container_name(protocol_type)} "
-            "sh -c 'head -c 8000000 /proc/net/nf_conntrack 2>/dev/null'"
+            f'docker exec -i {container} sh -c "{awk_prog}"'
         )
         if code != 0 or not out.strip():
             return {}
 
         counts = {}
         for line in out.split('\n'):
-            # First src= on the line is the original (initiator) tuple
-            m = re.search(r'\bsrc=(\d+\.\d+\.\d+\.\d+)', line)
-            if not m:
+            parts = line.split()
+            if len(parts) != 2:
                 continue
-            ip = m.group(1)
+            cnt_s, ip = parts
             try:
                 if ipaddress.ip_address(ip) in network:
-                    counts[ip] = counts.get(ip, 0) + 1
+                    counts[ip] = int(cnt_s)
             except ValueError:
                 continue
         return counts
+
+    def _conn_counts_path(self):
+        """Path inside container with the latest per-IP connection counts."""
+        return '/opt/amnezia/awg/conn_counts.json'
+
+    def _load_conn_counts(self, protocol_type):
+        """Load latest {ip: count} snapshot written by the collector."""
+        container_name = self._container_name(protocol_type)
+        out, err, code = self.ssh.run_sudo_command(
+            f"docker exec -i {container_name} cat {self._conn_counts_path()} 2>/dev/null"
+        )
+        if code != 0 or not out.strip():
+            return {}
+        try:
+            data = json.loads(out)
+            return {k: int(v) for k, v in data.items()} if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return {}
+
+    def _save_conn_counts(self, protocol_type, counts):
+        """Persist the {ip: count} snapshot into the container."""
+        container_name = self._container_name(protocol_type)
+        self.ssh.upload_file(json.dumps(counts), "/tmp/_amnz_conncount.json")
+        self.ssh.run_sudo_command(
+            f"docker cp /tmp/_amnz_conncount.json {container_name}:{self._conn_counts_path()}"
+        )
+        self.ssh.run_command("rm -f /tmp/_amnz_conncount.json")
+
+    def collect_conn_stats(self, protocol_type):
+        """Background collector: one cheap SSH roundtrip per instance.
+
+        Counts conntrack entries per peer IP inside the container (compact
+        awk summary, no raw table transfer), saves the snapshot and records
+        flood warnings. Called by the panel's background monitor so that
+        detection runs 24/7 even when nobody has the UI open.
+        """
+        counts = self._count_connections_by_ip(protocol_type)
+        if not counts:
+            return False
+        try:
+            self._save_conn_counts(protocol_type, counts)
+        except Exception as e:
+            logger.warning(f'failed to save conn counts: {e}')
+        self._update_conn_warnings(protocol_type, counts)
+        return True
 
     def _load_conn_warnings(self, protocol_type):
         """Load recorded warnings {ip: [{ts, count}, ...]} from the container."""

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1746,6 +1746,29 @@ a:hover {
     100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
 }
 
+/* Peer internal IP shown next to the client name */
+.client-ip {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Connection flood warnings (P2P/torrent detection) */
+.conn-warnings {
+    margin-top: 4px;
+}
+
+.conn-warning {
+    font-size: 0.75rem;
+    color: #f59e0b;
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    border-radius: var(--radius-sm, 6px);
+    padding: 3px 8px;
+    margin-top: 3px;
+    font-variant-numeric: tabular-nums;
+}
+
 /* ===== Header Navigation ===== */
 .header-nav {
     display: flex;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1746,13 +1746,6 @@ a:hover {
     100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
 }
 
-/* Peer internal IP shown next to the client name */
-.client-ip {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    font-variant-numeric: tabular-nums;
-}
-
 /* Connection flood warnings (P2P/torrent detection) */
 .conn-warnings {
     margin-top: 4px;

--- a/templates/server.html
+++ b/templates/server.html
@@ -2070,6 +2070,25 @@
                 if (assignedUser) metaHtml += `<span class="badge badge-info" style="font-size:0.65rem;">👤 ${escapeHtml(assignedUser)}</span>`;
                 if (created) metaHtml += `<span>📅 ${formatDate(created)}</span>`;
 
+                // Peer internal IP shown next to the name
+                const peerIp = userData.clientIp || ((userData.allowedIps || '').match(/(\d+\.\d+\.\d+\.\d+)/) || [])[1] || '';
+                const ipHtml = peerIp ? ` <span class="client-ip">${escapeHtml(peerIp)}</span>` : '';
+
+                // Connection flood warnings (P2P/torrent detection), newest last
+                let warningsHtml = '';
+                if (Array.isArray(userData.connWarnings) && userData.connWarnings.length) {
+                    warningsHtml = '<div class="conn-warnings">' + userData.connWarnings.map(ev => {
+                        const d = new Date(ev.ts * 1000);
+                        const dateStr = String(d.getDate()).padStart(2, '0') + '.' + String(d.getMonth() + 1).padStart(2, '0') + '.' + d.getFullYear();
+                        const timeStr = String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+                        const text = _('conn_warning_text')
+                            .replace('{date}', dateStr)
+                            .replace('{time}', timeStr)
+                            .replace('{count}', ev.count);
+                        return `<div class="conn-warning">${escapeHtml(text)}</div>`;
+                    }).join('') + '</div>';
+                }
+
                 if (proto === 'telemt') {
                     if (userData.total_octets) metaHtml += `<span class="traffic-badge">📊 ${formatBytes(userData.total_octets)}</span>`;
                     if (userData.current_connections !== undefined) metaHtml += `<span>🔌 ${userData.current_connections} conns</span>`;
@@ -2098,8 +2117,9 @@
                         <div class="client-info">
                             <div class="client-avatar${client._online ? ' avatar-online' : ''}">${initial}</div>
                             <div>
-                                <div class="client-name">${escapeHtml(name)}</div>
+                                <div class="client-name">${escapeHtml(name)}${ipHtml}</div>
                                 <div class="client-meta">${metaHtml || `<span class="text-muted">${_('no_data')}</span>`}</div>
+                                ${warningsHtml}
                             </div>
                         </div>
                         <div class="client-actions">

--- a/templates/server.html
+++ b/templates/server.html
@@ -2070,10 +2070,6 @@
                 if (assignedUser) metaHtml += `<span class="badge badge-info" style="font-size:0.65rem;">👤 ${escapeHtml(assignedUser)}</span>`;
                 if (created) metaHtml += `<span>📅 ${formatDate(created)}</span>`;
 
-                // Peer internal IP shown next to the name
-                const peerIp = userData.clientIp || ((userData.allowedIps || '').match(/(\d+\.\d+\.\d+\.\d+)/) || [])[1] || '';
-                const ipHtml = peerIp ? ` <span class="client-ip">${escapeHtml(peerIp)}</span>` : '';
-
                 // Connection flood warnings (P2P/torrent detection), newest last
                 let warningsHtml = '';
                 if (Array.isArray(userData.connWarnings) && userData.connWarnings.length) {
@@ -2117,7 +2113,7 @@
                         <div class="client-info">
                             <div class="client-avatar${client._online ? ' avatar-online' : ''}">${initial}</div>
                             <div>
-                                <div class="client-name">${escapeHtml(name)}${ipHtml}</div>
+                                <div class="client-name">${escapeHtml(name)}</div>
                                 <div class="client-meta">${metaHtml || `<span class="text-muted">${_('no_data')}</span>`}</div>
                                 ${warningsHtml}
                             </div>

--- a/templates/server.html
+++ b/templates/server.html
@@ -2082,7 +2082,8 @@
                             .replace('{time}', timeStr)
                             .replace('{count}', ev.count);
                         return `<div class="conn-warning">${escapeHtml(text)}</div>`;
-                    }).join('') + '</div>';
+                    }).join('') +
+                    `<button class="btn btn-secondary btn-sm btn-icon conn-warning-clear" onclick="clearConnWarnings('${escapeJs(client.clientId)}')" title="${_('clear_warnings')}" style="margin-top:4px;">🗑</button></div>`;
                 }
 
                 if (proto === 'telemt') {
@@ -2249,6 +2250,20 @@
                 protocol: proto, client_id: clientId,
             });
             showToast(_('connection_deleted'), 'success');
+            loadConnections();
+        } catch (err) {
+            showToast(_('error') + ': ' + err.message, 'error');
+        }
+    }
+
+    // Clear connection-flood (torrent) warnings history for a peer
+    async function clearConnWarnings(clientId) {
+        const proto = document.getElementById('connProtoSelect').value;
+        try {
+            await apiCall(`/api/servers/${SERVER_ID}/connections/clear_warnings`, 'POST', {
+                protocol: proto, client_id: clientId,
+            });
+            showToast(_('warnings_cleared'), 'success');
             loadConnections();
         } catch (err) {
             showToast(_('error') + ': ' + err.message, 'error');

--- a/translations/en.json
+++ b/translations/en.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Reset traffic",
   "resetting": "Resetting...",
   "reset_traffic_confirm": "Reset this user's current traffic? Total statistics will be kept.",
-  "traffic_reset_success": "Traffic reset"
+  "traffic_reset_success": "Traffic reset",
+  "conn_warning_text": "⚠️ Warning: {count} connections opened at {time} on {date}!"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -437,5 +437,7 @@
   "resetting": "Resetting...",
   "reset_traffic_confirm": "Reset this user's current traffic? Total statistics will be kept.",
   "traffic_reset_success": "Traffic reset",
-  "conn_warning_text": "⚠️ Warning: {count} connections opened at {time} on {date}!"
+  "conn_warning_text": "⚠️ Warning: {count} connections opened at {time} on {date}!",
+  "clear_warnings": "Clear warnings",
+  "warnings_cleared": "Warnings cleared"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -403,5 +403,6 @@
   "reset_traffic": "بازنشانی ترافیک",
   "resetting": "در حال بازنشانی...",
   "reset_traffic_confirm": "ترافیک فعلی این کاربر بازنشانی شود؟ آمار کل حفظ میشود.",
-  "traffic_reset_success": "ترافیک بازنشانی شد"
+  "traffic_reset_success": "ترافیک بازنشانی شد",
+  "conn_warning_text": "⚠️ هشدار: در {date} ساعت {time} تعداد {count} اتصال باز شد!"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -404,5 +404,7 @@
   "resetting": "در حال بازنشانی...",
   "reset_traffic_confirm": "ترافیک فعلی این کاربر بازنشانی شود؟ آمار کل حفظ میشود.",
   "traffic_reset_success": "ترافیک بازنشانی شد",
-  "conn_warning_text": "⚠️ هشدار: در {date} ساعت {time} تعداد {count} اتصال باز شد!"
+  "conn_warning_text": "⚠️ هشدار: در {date} ساعت {time} تعداد {count} اتصال باز شد!",
+  "clear_warnings": "پاک کردن هشدارها",
+  "warnings_cleared": "هشدارها پاک شدند"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -403,5 +403,6 @@
   "reset_traffic": "Réinitialiser le trafic",
   "resetting": "Réinitialisation...",
   "reset_traffic_confirm": "Réinitialiser le trafic actuel de cet utilisateur ? Les statistiques totales seront conservées.",
-  "traffic_reset_success": "Trafic réinitialisé"
+  "traffic_reset_success": "Trafic réinitialisé",
+  "conn_warning_text": "⚠️ Attention : {count} connexions ouvertes le {date} à {time} !"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -404,5 +404,7 @@
   "resetting": "Réinitialisation...",
   "reset_traffic_confirm": "Réinitialiser le trafic actuel de cet utilisateur ? Les statistiques totales seront conservées.",
   "traffic_reset_success": "Trafic réinitialisé",
-  "conn_warning_text": "⚠️ Attention : {count} connexions ouvertes le {date} à {time} !"
+  "conn_warning_text": "⚠️ Attention : {count} connexions ouvertes le {date} à {time} !",
+  "clear_warnings": "Effacer les avertissements",
+  "warnings_cleared": "Avertissements effacés"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Сбросить трафик",
   "resetting": "Сброс...",
   "reset_traffic_confirm": "Сбросить текущий трафик пользователя? Общая статистика сохранится.",
-  "traffic_reset_success": "Трафик сброшен"
+  "traffic_reset_success": "Трафик сброшен",
+  "conn_warning_text": "⚠️ Внимание: {date} в {time} открыто {count} соединений!"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -437,5 +437,7 @@
   "resetting": "Сброс...",
   "reset_traffic_confirm": "Сбросить текущий трафик пользователя? Общая статистика сохранится.",
   "traffic_reset_success": "Трафик сброшен",
-  "conn_warning_text": "⚠️ Внимание: {date} в {time} открыто {count} соединений!"
+  "conn_warning_text": "⚠️ Внимание: {date} в {time} открыто {count} соединений!",
+  "clear_warnings": "Очистить предупреждения",
+  "warnings_cleared": "Предупреждения очищены"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -403,5 +403,6 @@
   "reset_traffic": "重置流量",
   "resetting": "正在重置...",
   "reset_traffic_confirm": "重置此用户的当前流量？总统计将保留。",
-  "traffic_reset_success": "流量已重置"
+  "traffic_reset_success": "流量已重置",
+  "conn_warning_text": "⚠️ 警告：{date} {time} 打开了 {count} 个连接！"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -404,5 +404,7 @@
   "resetting": "正在重置...",
   "reset_traffic_confirm": "重置此用户的当前流量？总统计将保留。",
   "traffic_reset_success": "流量已重置",
-  "conn_warning_text": "⚠️ 警告：{date} {time} 打开了 {count} 个连接！"
+  "conn_warning_text": "⚠️ 警告：{date} {time} 打开了 {count} 个连接！",
+  "clear_warnings": "清除警告",
+  "warnings_cleared": "警告已清除"
 }


### PR DESCRIPTION
## Что добавляет

Индикация пиров с аномально большим числом одновременных соединений — типичный признак торрентов/P2P, которые забивают conntrack и полосу сервера.

Под карточкой пира появляются предупреждения вида:

> ⚠️ 21.08.2026 at 23:56 was opened 7777 connections! 🗑

(текст локализован, язык берётся из настроек панели; кнопка 🗑 стирает историю предупреждений пира)

## Как работает

- **Фоновый монитор на стороне панели** (поток, стартует с приложением) раз в 10 минут обходит все серверы/AWG-инстансы и собирает счётчики — детекция работает 24/7, даже когда никто не держит UI открытым.
- Подсчёт ведётся **внутри контейнера инстанса** по `/proc/net/nf_conntrack` (NAT подсети VPN живёт в netns контейнера, на хосте виден только IP контейнера).
- Вместо выкачивания многомегабайтной таблицы по SSH передаётся только компактная сводка `count ip` (пайплайн `tr/grep/cut/sort/uniq` — безопасен для вложенных шеллов ssh + `sh -c`, в отличие от awk с `$i`).
- Снимок пишется в `conn_counts.json`, предупреждения — в `conn_warnings.json` в data-каталоге контейнера (volume-backed, переживает рестарты). UI при опросе пиров только читает эти файлы — нулевая дополнительная нагрузка на страницу.
- Порог: **600 одновременных соединений**. Обычный веб/мессенджеры/почта столько не открывают (проверено вживую: активный торрент-клиент даёт 200–700, обычные пиры — десятки).
- Антиспам: не чаще одного предупреждения в час на пира, хранятся последние 5 событий (новые сверху).

## Что НЕ входит

Никаких автоматических блокировок — только индикация, админ сам решает что делать с нарушителем. (Авто-бан в планах.)

## Замечания

- Фича покрывает AWG-инстансы (awg/awg2/awg3); для xray не применимо.
- IP-бейдж рядом с именем пира вынесен в отдельный PR (#99), чтобы PR не пересекались.
- Проверено на живой установке: панель на VPS в Европе, инстансы в РФ — счётчики и предупреждения корректно собираются и отображаются.