### PR TITLE
fix(awg): raise nf_conntrack_max on install — default too low for a VPN gateway

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -435,12 +435,27 @@ fi
         return True
 
     def setup_firewall(self):
-        """Setup host firewall (mirrors setup_host_firewall.sh)."""
+        """Setup host firewall (mirrors setup_host_firewall.sh).
+
+        Also raises net.netfilter.nf_conntrack_max: the default on small
+        VMs can be as low as ~7680 entries, and every client flow through
+        the NAT consumes one entry. A full conntrack table makes the
+        kernel silently drop packets ("nf_conntrack: table full"), which
+        users see as random connection freezes. 262144 is a safe value
+        for a VPN gateway; persisted via /etc/sysctl.d.
+        """
         script = """
 sysctl -w net.ipv4.ip_forward=1
 sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
 iptables -C INPUT -p icmp --icmp-type echo-request -j DROP 2>/dev/null || iptables -A INPUT -p icmp --icmp-type echo-request -j DROP
 iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-USER 2>/dev/null
+if [ -f /proc/sys/net/netfilter/nf_conntrack_max ]; then
+    cur=$(cat /proc/sys/net/netfilter/nf_conntrack_max)
+    if [ "$cur" -lt 262144 ] 2>/dev/null; then
+        printf '%s\n' 'net.netfilter.nf_conntrack_max = 262144' > /etc/sysctl.d/98-awp-conntrack.conf
+        sysctl -w net.netfilter.nf_conntrack_max=262144
+    fi
+fi
 """
         self.ssh.run_sudo_script(script)
         return True


### PR DESCRIPTION
## Problem

`net.netfilter.nf_conntrack_max` on small VMs defaults to very low values — e.g. **7680** on a fresh 1 GB Debian/Ubuntu VPS. Every client flow passing through the VPN NAT consumes one conntrack entry, so just a few active peers (browsers, torrents, app updates) fill the table. Once full, the kernel drops packets with `nf_conntrack: table full, dropping packet` — users experience random connection freezes and slowdowns that are very hard to diagnose.

## Fix

During `setup_firewall()` (runs on every AWG protocol install), check `nf_conntrack_max` and raise it to **262144** when the current value is lower:

- applied immediately via `sysctl -w`
- persisted across reboots via `/etc/sysctl.d/98-awp-conntrack.conf`
- skipped when the current value is already higher (never lowers an admin's custom setting)
- skipped entirely when the kernel has no conntrack module (`/proc/sys/net/netfilter/nf_conntrack_max` absent)

## Testing

Verified on Debian 13 (kernel 6.x) and Ubuntu 20.04 (5.15 HWE): after install, `sysctl net.netfilter.nf_conntrack_max` returns 262144; existing higher values are left untouched.