### PR TITLE
feat(awg): container network tuning, host BBR, and tuning status modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -2991,6 +2991,27 @@ async def api_server_config(request: Request, server_id: int, req: ProtocolReque
         return JSONResponse({'error': str(e)}, status_code=500)
 
 
+@app.post('/api/servers/{server_id}/host_tuning', tags=["Protocols"])
+async def api_host_tuning(request: Request, server_id: int):
+    """Server-level network tuning summary (host sysctls + AWG containers)."""
+    if not _check_admin(request):
+        return JSONResponse({'error': 'Forbidden'}, status_code=403)
+    try:
+        data = load_data()
+        if server_id >= len(data['servers']):
+            return JSONResponse({'error': 'Server not found'}, status_code=404)
+        server = data['servers'][server_id]
+        ssh = get_ssh(server)
+        ssh.connect()
+        mgr = AWGManager(ssh)
+        info = mgr.get_host_tuning()
+        ssh.disconnect()
+        return info
+    except Exception as e:
+        logger.exception("Error getting host tuning info")
+        return JSONResponse({'error': str(e)}, status_code=500)
+
+
 @app.post('/api/servers/{server_id}/server_config/save', tags=["Protocols"])
 async def api_server_config_save(request: Request, server_id: int, req: ServerConfigSaveRequest):
     """Save the raw server-side WireGuard/Xray configuration and apply changes."""

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -445,6 +445,78 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         self.ssh.run_sudo_script(script)
         return True
 
+    def setup_host_tuning(self):
+        """Enable BBR congestion control on the host (with persistence).
+
+        BBR is available in all kernels >= 4.9 (any modern Debian/Ubuntu).
+        If the tcp_bbr module is not loaded, load it and persist across
+        reboots. Falls back silently when the kernel has no BBR support.
+        BBR significantly outperforms cubic on lossy paths, which VPN
+        tunnels often traverse.
+        """
+        script = """
+set -e
+if ! sysctl -n net.ipv4.tcp_available_congestion_control 2>/dev/null | grep -qw bbr; then
+    modprobe tcp_bbr 2>/dev/null || true
+fi
+if sysctl -n net.ipv4.tcp_available_congestion_control 2>/dev/null | grep -qw bbr; then
+    echo tcp_bbr > /etc/modules-load.d/awp-bbr.conf
+    printf '%s\\n' \\
+        'net.core.default_qdisc = fq' \\
+        'net.ipv4.tcp_congestion_control = bbr' \\
+        > /etc/sysctl.d/99-awp-bbr.conf
+    sysctl -w net.core.default_qdisc=fq
+    sysctl -w net.ipv4.tcp_congestion_control=bbr
+fi
+"""
+        try:
+            self.ssh.run_sudo_script(script)
+        except Exception as err:
+            logger.warning(f"setup_host_tuning warning: {err}")
+        return True
+
+    def get_host_tuning(self):
+        """Read live network-tuning state for the whole server (host + all
+        AWG containers). Used by the server-level "Host tuning" modal.
+        """
+        script = """
+echo "HOST_CC=$(sysctl -n net.ipv4.tcp_congestion_control 2>/dev/null)"
+echo "HOST_QDISC=$(sysctl -n net.core.default_qdisc 2>/dev/null)"
+echo "HOST_CONNTRACK=$(cat /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null)"
+echo "HOST_CONNTRACK_COUNT=$(cat /proc/sys/net/netfilter/nf_conntrack_count 2>/dev/null)"
+echo "HOST_BACKLOG=$(sysctl -n net.core.netdev_max_backlog 2>/dev/null)"
+echo "HOST_SOMAXCONN=$(sysctl -n net.core.somaxconn 2>/dev/null)"
+for c in $(docker ps -a --format '{{.Names}}' | grep '^amnezia-awg' | sort); do
+  echo "CT_NAME=$c"
+  if docker ps --format '{{.Names}}' | grep -qx "$c"; then
+    echo "CT_RUNNING=1"
+    docker exec "$c" sh -c 'for p in net.core.rmem_max net.core.wmem_max net.ipv4.tcp_fastopen net.ipv4.tcp_mtu_probing; do echo "CTK_$p=$(sysctl -n $p 2>/dev/null)"; done; echo "CTK_nofile=$(ulimit -n)"' 2>/dev/null
+  else
+    echo "CT_RUNNING=0"
+  fi
+done
+"""
+        out, err, code = self.ssh.run_sudo_command(script, timeout=60)
+        info = {'host': {}, 'containers': []}
+        if code != 0 or not out:
+            return info
+        current = None
+        for line in out.splitlines():
+            if '=' not in line:
+                continue
+            key, _, val = line.partition('=')
+            key, val = key.strip(), val.strip()
+            if key.startswith('HOST_'):
+                info['host'][key[5:].lower()] = val
+            elif key == 'CT_NAME':
+                current = {'name': val, 'running': False, 'ct': {}}
+                info['containers'].append(current)
+            elif key == 'CT_RUNNING' and current is not None:
+                current['running'] = val == '1'
+            elif key.startswith('CTK_') and current is not None:
+                current['ct'][key[4:]] = val
+        return info
+
     def install_protocol(self, protocol_type, port=None, awg_params=None):
         """
         Full installation of AWG or AWG-Legacy protocol.
@@ -504,8 +576,32 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
             f"\n"
             f"RUN mkdir -p /opt/amnezia\n"
             f'RUN echo "#!/bin/bash" > /opt/amnezia/start.sh && '
+            f'echo "sysctl -p /etc/sysctl.conf 2>/dev/null || true" >> /opt/amnezia/start.sh && '
             f'echo "tail -f /dev/null" >> /opt/amnezia/start.sh\n'
             f"RUN chmod a+x /opt/amnezia/start.sh\n"
+            f"\n"
+            f"# Network tuning (mirrors AmneziaVPN container tuning)\n"
+            f"RUN printf '%s\\n' \\\n"
+            f"'fs.file-max = 51200' \\\n"
+            f"'net.core.rmem_max = 67108864' \\\n"
+            f"'net.core.wmem_max = 67108864' \\\n"
+            f"'net.core.netdev_max_backlog = 250000' \\\n"
+            f"'net.core.somaxconn = 4096' \\\n"
+            f"'net.ipv4.tcp_syncookies = 1' \\\n"
+            f"'net.ipv4.tcp_tw_reuse = 1' \\\n"
+            f"'net.ipv4.tcp_fin_timeout = 30' \\\n"
+            f"'net.ipv4.tcp_keepalive_time = 1200' \\\n"
+            f"'net.ipv4.ip_local_port_range = 10000 65000' \\\n"
+            f"'net.ipv4.tcp_max_syn_backlog = 8192' \\\n"
+            f"'net.ipv4.tcp_max_tw_buckets = 5000' \\\n"
+            f"'net.ipv4.tcp_fastopen = 3' \\\n"
+            f"'net.ipv4.tcp_mem = 25600 51200 102400' \\\n"
+            f"'net.ipv4.tcp_rmem = 4096 87380 67108864' \\\n"
+            f"'net.ipv4.tcp_wmem = 4096 65536 67108864' \\\n"
+            f"'net.ipv4.tcp_mtu_probing = 1' \\\n"
+            f" >> /etc/sysctl.conf && \\\n"
+            f"mkdir -p /etc/security && \\\n"
+            f"printf '%s\\n' '* soft nofile 51200' '* hard nofile 51200' >> /etc/security/limits.conf\n"
             f"\n"
             f'ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]\n'
         )
@@ -530,6 +626,7 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
 -p {port}:{port}/udp \
 -v /lib/modules:/lib/modules \
 --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
+--ulimit nofile=51200:51200 \
 --name {container_name} \
 {container_name}"""
 
@@ -565,6 +662,11 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         results.append("Setting up firewall...")
         self.setup_firewall()
         results.append("Firewall configured")
+
+        # Step 9: Host network tuning (BBR)
+        results.append("Applying host network tuning (BBR)...")
+        self.setup_host_tuning()
+        results.append("Host network tuning applied")
 
         return {
             'status': 'success',
@@ -704,6 +806,9 @@ EOF
 
         start_script = f"""#!/bin/bash
 echo "Container startup"
+
+# Apply container network tuning (see Dockerfile)
+sysctl -p /etc/sysctl.conf 2>/dev/null || true
 
 # Read subnet from server config dynamically (IPv4 part of the Address line)
 SUBNET=$(grep '^Address' {config_path} | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
@@ -857,6 +962,9 @@ tail -f /dev/null
         quick_bin = self._quick_binary(protocol_type)
         start_script = f"""#!/bin/bash
 echo "Container startup"
+
+# Apply container network tuning (see Dockerfile)
+sysctl -p /etc/sysctl.conf 2>/dev/null || true
 
 # Read subnet from server config dynamically (IPv4 part of the Address line)
 SUBNET=$(grep '^Address' {config_path} | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')

--- a/templates/server.html
+++ b/templates/server.html
@@ -151,6 +151,9 @@
                 <button class="btn btn-secondary btn-sm" onclick="openManagementModal()" id="managementBtn">
                     <span>⚙️</span> {{ _('management') }}
                 </button>
+                <button class="btn btn-secondary btn-sm" onclick="openHostTuning()" id="hostTuningBtn">
+                    <span>📊</span> {{ _('host_tuning') }}
+                </button>
             </div>
         </div>
     </div>
@@ -946,6 +949,16 @@
         </div>
     </div>
 </div>
+<!-- ===== Host Tuning Modal ===== -->
+<div class="modal-backdrop" id="hostTuningModal">
+    <div class="modal" style="max-width:520px;">
+        <div class="modal-header">
+            <h2 class="modal-title">📊 {{ _('host_tuning') }}</h2>
+            <button class="modal-close" onclick="closeModal('hostTuningModal')">×</button>
+        </div>
+        <div id="hostTuningBody" style="margin-top:var(--space-md); font-size:12px; line-height:1.6;"></div>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -1637,6 +1650,45 @@
         } catch (err) {
             showToast(_('error') + ': ' + err.message, 'error');
         }
+    }
+
+    // Host network tuning modal (server-level)
+    async function openHostTuning() {
+        try {
+            showToast(_('loading'), 'info');
+            const res = await apiCall(`/api/servers/${SERVER_ID}/host_tuning`, 'POST', {});
+            renderHostTuning(res);
+            openModal('hostTuningModal');
+        } catch (err) {
+            showToast(_('error') + ': ' + err.message, 'error');
+        }
+    }
+
+    function renderHostTuning(t) {
+        const el = document.getElementById('hostTuningBody');
+        if (!el) return;
+        if (!t) { el.innerHTML = ''; return; }
+        const esc = s => String(s ?? '—').replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+        const row = (k, v) => `<div style="display:flex;justify-content:space-between;gap:12px;"><span style="opacity:.7">${k}</span><code>${esc(v)}</code></div>`;
+        let html = '';
+        const h = t.host || {};
+        html += `<div style="opacity:.85;font-weight:600;margin-bottom:2px;">Host</div>`;
+        html += row('congestion control', h.cc);
+        html += row('qdisc', h.qdisc);
+        html += row('conntrack', `${h.conntrack_count || 0} / ${h.conntrack || '—'}`);
+        html += row('netdev_max_backlog', h.netdev_max_backlog);
+        html += row('somaxconn', h.somaxconn);
+        for (const c of (t.containers || [])) {
+            html += `<div style="font-weight:600;margin:12px 0 2px;">🐳 ${esc(c.name)} ${c.running ? '<span style="color:var(--success,#3fb950)">● online</span>' : '<span style="color:var(--danger,#f85149)">● stopped</span>'}</div>`;
+            if (c.running && c.ct) {
+                html += row('rmem_max / wmem_max', `${c.ct['net.core.rmem_max'] || '—'} / ${c.ct['net.core.wmem_max'] || '—'}`);
+                html += row('tcp_fastopen', c.ct['net.ipv4.tcp_fastopen']);
+                html += row('tcp_mtu_probing', c.ct['net.ipv4.tcp_mtu_probing']);
+                html += row('nofile (ulimit -n)', c.ct['nofile']);
+            }
+        }
+        if (!(t.containers || []).length) html += `<div style="opacity:.6;margin-top:8px;">No AWG containers</div>`;
+        el.innerHTML = html;
     }
 
     // Save server config changes

--- a/translations/en.json
+++ b/translations/en.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Reset traffic",
   "resetting": "Resetting...",
   "reset_traffic_confirm": "Reset this user's current traffic? Total statistics will be kept.",
-  "traffic_reset_success": "Traffic reset"
+  "traffic_reset_success": "Traffic reset",
+  "host_tuning": "Host tuning"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -403,5 +403,6 @@
   "reset_traffic": "بازنشانی ترافیک",
   "resetting": "در حال بازنشانی...",
   "reset_traffic_confirm": "ترافیک فعلی این کاربر بازنشانی شود؟ آمار کل حفظ میشود.",
-  "traffic_reset_success": "ترافیک بازنشانی شد"
+  "traffic_reset_success": "ترافیک بازنشانی شد",
+  "host_tuning": "تنظیمات میزبان"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -403,5 +403,6 @@
   "reset_traffic": "Réinitialiser le trafic",
   "resetting": "Réinitialisation...",
   "reset_traffic_confirm": "Réinitialiser le trafic actuel de cet utilisateur ? Les statistiques totales seront conservées.",
-  "traffic_reset_success": "Trafic réinitialisé"
+  "traffic_reset_success": "Trafic réinitialisé",
+  "host_tuning": "Réglages hôte"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Сбросить трафик",
   "resetting": "Сброс...",
   "reset_traffic_confirm": "Сбросить текущий трафик пользователя? Общая статистика сохранится.",
-  "traffic_reset_success": "Трафик сброшен"
+  "traffic_reset_success": "Трафик сброшен",
+  "host_tuning": "Конфигурация"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -403,5 +403,6 @@
   "reset_traffic": "重置流量",
   "resetting": "正在重置...",
   "reset_traffic_confirm": "重置此用户的当前流量？总统计将保留。",
-  "traffic_reset_success": "流量已重置"
+  "traffic_reset_success": "流量已重置",
+  "host_tuning": "主机调优"
 }


### PR DESCRIPTION
## Summary

Adds the network tuning that the AmneziaVPN desktop client applies to its AWG containers, plus host-side BBR, plus a small status UI. Verified on production servers (Debian 13, Ubuntu 20.04/5.15).

### Container image (Dockerfile)

- Writes sysctl tuning into `/etc/sysctl.conf`: 64 MB socket buffers (`rmem_max`/`wmem_max`), `netdev_max_backlog=250000`, `somaxconn=4096`, `tcp_fastopen=3`, `tcp_mtu_probing=1`, TCP keepalive/mem/wmem tuning — the same set AmneziaVPN uses, minus `hybla` congestion control which requires a host kernel module.
- `start.sh` now runs `sysctl -p /etc/sysctl.conf` at container start — Alpine does not apply sysctl.conf by itself, so without this the values would be dead text.
- `docker run` gets `--ulimit nofile=51200:51200` (`/etc/security/limits.conf` has no effect on containers — limits are set by the Docker daemon).

### Host (new `setup_host_tuning()` step in `install_protocol`)

- Enables **BBR** congestion control + `fq` qdisc (BBR requires fq for pacing). Loads `tcp_bbr` if needed; persists via `/etc/sysctl.d/99-awp-bbr.conf` and `/etc/modules-load.d/awp-bbr.conf`. Silently skipped when the kernel lacks BBR.
- BBR holds throughput on lossy paths where cubic collapses — typical for VPN traffic crossing congested ISP links.

### UI

- New **"📊 Host tuning"** button in the server status bar opens a modal showing live host sysctls (congestion control, qdisc, conntrack usage/max, backlog, somaxconn) and per-AWG-container values (buffers, fastopen, mtu_probing, nofile) with container online status.
- Adds `POST /api/servers/{id}/host_tuning` and `host_tuning` translation key (en/ru/fr/fa/zh).

### Notes

- Existing containers keep old settings until reinstalled (image is built at install time) — this is expected.
- Complements #101 (conntrack), which touches a different function.