### PR TITLE
fix(awg): auto-enable Docker IPv6 so dual-stack instances actually work

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -541,6 +541,17 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
 
         # Step 5: Run container
         results.append("Starting container...")
+        # Detect host IPv6 BEFORE creating the container: the netns
+        # disable_ipv6 flags are fixed at container creation time, so a
+        # container started without these sysctls can never add an IPv6
+        # address to a tunnel interface (ip -6 address add -> RTNETLINK
+        # Permission denied, and awg-quick then deletes the whole awg0).
+        ipv6_enabled = self._detect_server_ipv6()
+        ipv6_sysctls = (
+            '--sysctl="net.ipv6.conf.all.disable_ipv6=0" \\\n'
+            '--sysctl="net.ipv6.conf.default.disable_ipv6=0" \\\n'
+            if ipv6_enabled else ''
+        )
         run_cmd = f"""docker run -d \
 --restart always \
 --privileged \
@@ -549,7 +560,7 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
 -p {port}:{port}/udp \
 -v /lib/modules:/lib/modules \
 --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
---name {container_name} \
+{ipv6_sysctls}--name {container_name} \
 {container_name}"""
 
         out, err, code = self.ssh.run_sudo_command(run_cmd)
@@ -566,7 +577,6 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
 
         # Step 6: Configure container (generate server keys and config)
         results.append("Configuring AWG...")
-        ipv6_enabled = self._detect_server_ipv6()
         results.append(
             "IPv6 detected on host, enabling dual-stack tunnel"
             if ipv6_enabled else

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -430,22 +430,29 @@ if ! docker network ls | grep -q amnezia-dns-net; then
 fi
 # Enable Docker IPv6 when the host has a global IPv6 address. Without this
 # containers get no IPv6 route and dual-stack tunnels silently fall back
-# to IPv4-only. daemon.json is merged (not overwritten) and backed up.
+# to IPv4-only. Also enable ip6tables (+experimental): without them Docker
+# sets no NAT66 for the fixed-cidr-v6 ULA subnet and v6 traffic blackholes.
+# daemon.json is merged (not overwritten), backed up, docker restarted
+# only when the file actually changed.
 if ip -6 -o addr show scope global 2>/dev/null | grep -q inet6; then
-  if ! grep -q '"ipv6"' /etc/docker/daemon.json 2>/dev/null; then
-    [ -f /etc/docker/daemon.json ] && cp /etc/docker/daemon.json /etc/docker/daemon.json.bak.awp
-    python3 - <<'PYEOF' 2>/dev/null || echo '{{"ipv6": true, "fixed-cidr-v6": "fd00:42::/64"}}' > /etc/docker/daemon.json
-import json, os
+  cp /etc/docker/daemon.json /etc/docker/daemon.json.bak.awp 2>/dev/null
+  python3 - <<'PYEOF' 2>/dev/null || (grep -q '"ipv6"' /etc/docker/daemon.json 2>/dev/null || (echo '{{"ipv6": true, "fixed-cidr-v6": "fd00:42::/64", "experimental": true, "ip6tables": true}}' > /etc/docker/daemon.json && systemctl restart docker))
+import json, os, subprocess
 p = '/etc/docker/daemon.json'
 d = {{}}
 if os.path.exists(p):
     d = json.load(open(p))
-d['ipv6'] = True
-d.setdefault('fixed-cidr-v6', 'fd00:42::/64')
-json.dump(d, open(p, 'w'), indent=2)
+need = {{'ipv6': True, 'experimental': True, 'ip6tables': True}}
+changed = False
+for k, v in need.items():
+    if d.get(k) != v:
+        d[k] = v; changed = True
+if 'fixed-cidr-v6' not in d:
+    d['fixed-cidr-v6'] = 'fd00:42::/64'; changed = True
+if changed:
+    json.dump(d, open(p, 'w'), indent=2)
+    subprocess.run(['systemctl', 'restart', 'docker'], check=False)
 PYEOF
-    systemctl restart docker
-  fi
 fi
 """
         out, err, code = self.ssh.run_sudo_script(script)

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -428,6 +428,25 @@ mkdir -p {dockerfile_folder}
 if ! docker network ls | grep -q amnezia-dns-net; then
   docker network create --driver bridge --subnet=172.29.172.0/24 --opt com.docker.network.bridge.name=amn0 amnezia-dns-net
 fi
+# Enable Docker IPv6 when the host has a global IPv6 address. Without this
+# containers get no IPv6 route and dual-stack tunnels silently fall back
+# to IPv4-only. daemon.json is merged (not overwritten) and backed up.
+if ip -6 -o addr show scope global 2>/dev/null | grep -q inet6; then
+  if ! grep -q '"ipv6"' /etc/docker/daemon.json 2>/dev/null; then
+    [ -f /etc/docker/daemon.json ] && cp /etc/docker/daemon.json /etc/docker/daemon.json.bak.awp
+    python3 - <<'PYEOF' 2>/dev/null || echo '{{"ipv6": true, "fixed-cidr-v6": "fd00:42::/64"}}' > /etc/docker/daemon.json
+import json, os
+p = '/etc/docker/daemon.json'
+d = {{}}
+if os.path.exists(p):
+    d = json.load(open(p))
+d['ipv6'] = True
+d.setdefault('fixed-cidr-v6', 'fd00:42::/64')
+json.dump(d, open(p, 'w'), indent=2)
+PYEOF
+    systemctl restart docker
+  fi
+fi
 """
         out, err, code = self.ssh.run_sudo_script(script)
         if code != 0:


### PR DESCRIPTION
## Problem

The panel already writes dual-stack configs (`fd42:8:1::/64` server address, `fd42:8:1::N/128` peer addresses, NAT66 rules), but on a stock Docker install the daemon runs IPv4-only. Containers then have no IPv6 route out:

```
ping6 2606:4700:4700::1111 -> sendto: Network unreachable
```

Result: clients receive `fd42:...` addresses in their configs, but IPv6 traffic silently doesn't work — the tunnel is de facto IPv4-only. Reproduced on Debian 13 and Ubuntu 20.04 with default Docker settings.

## Fix — three layers, all required

### 1. Enable IPv6 + NAT66 in the Docker daemon (`prepare_host()`, runs before every AWG instance install)

When the host has a global IPv6 address, the panel now enforces four keys in `/etc/docker/daemon.json` (merged, never overwriting other settings; backed up to `daemon.json.bak.awp`):

- `"ipv6": true` + `"fixed-cidr-v6": "fd00:42::/64"` — containers get v6 addressing and a default route
- `"experimental": true` + `"ip6tables": true` — without these Docker programs **no NAT66 MASQUERADE rule** for the ULA subnet, so v6 packets leave the host with an unroutable `fd00:42::` source and blackhole

Docker is restarted only when the file actually changed. Keys are enforced unconditionally, so hosts that already have `"ipv6": true` but lack `ip6tables` still get fixed on the next install. IPv4-only hosts are untouched.

### 2. Enable IPv6 inside the container netns at creation time (`docker run`)

Even with an IPv6-enabled daemon, containers are created with `net.ipv6.conf.all.disable_ipv6 = 1`, and that flag is **fixed at network-namespace creation** — it cannot be changed afterwards:

```
[#] ip -4 address add 10.8.1.1/24 dev awg0     # OK
[#] ip -6 address add fd42:8:1::1/64 dev awg0  # RTNETLINK answers: Permission denied
[#] ip link delete dev awg0                    # awg-quick rolls back: awg0 is gone
```

Worse, awg-quick's rollback deletes the whole interface, so a failed IPv6 address add takes the working IPv4 tunnel down with it — the instance looks installed but passes no traffic at all.

So host IPv6 is detected **before** `docker run` and `--sysctl net.ipv6.conf.all.disable_ipv6=0` + `net.ipv6.conf.default.disable_ipv6=0` are passed at container creation. On IPv4-only hosts the sysctls are omitted, behaviour unchanged.

## Testing

Verified on live servers (Debian 13), layer by layer:

- Stock daemon: containers had no inet6 on eth0, ping6 failed.
- After layer 1 only: `ip -6 address add` failed with Permission denied and awg-quick deleted awg0 — tunnel fully dead.
- After layers 1+2 without `ip6tables`: interface up, v6 address and default route present, but ping6 100% loss — no NAT66 MASQUERADE on the host.
- After all layers: `disable_ipv6 = 0`, `fd00:42::` addressing works, host has `MASQUERADE ... fd00:42::/64`, ping6 succeeds, clients get working IPv6 through the tunnel (test-ipv6.com 10/10).