### PR TITLE
Keep AWG tunnels IPv4-only unless IPv6 works end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Configuration panel for system parameters and preferences:
 
 *   **⚡ VPN Protocols**:
     *   **AmneziaWG (AWG 3.1 / AWG 2.0 / AWG Legacy)**: Advanced WireGuard-based protocol with S3/S4 obfuscation to bypass deep packet inspection (DPI). Three coexisting variants — modern AWG 2.0 with full junk-packet masking, and a legacy variant for older clients.
+    *   **Dual-stack (IPv6)**: enabled automatically only when IPv6 works end-to-end — a global address on the host *and* an IPv6 default route inside the protocol container. Docker networks are IPv4-only unless the daemon is configured for IPv6, so a host-only check would hand clients an IPv6 address with no route out. Override with the `AWG_IPV6` environment variable: `auto` (default), `off` to keep every tunnel IPv4-only, `on` to force dual-stack.
     *   **Classic WireGuard**: Standard, high-performance WireGuard protocol for unmatched speed and broad device compatibility with traffic monitoring support.
     *   **Xray (XTLS-Reality)**: Stealthy protocol that masks VPN traffic as standard HTTPS browsing. Pinned to **Xray-core v26.x**; transparently reads both the **panel layout** (`meta.json` + `clientsTable.json`) and the **native Amnezia client layout** (`xray_*.key` files + `clientsTable`), so a node first installed via the official mobile/desktop app can be attached to the panel without re-installation.
     *   **Telemt (Telegram MTProxy)**: High-performance Telegram MTProxy with TLS emulation and comprehensive management (quotas, IP limits, real-time session tracking). Robust install path that auto-configures Docker's official apt/yum repository when needed.
@@ -266,6 +267,7 @@ web-panel/
 *   **Reverse Proxy**: It is highly recommended to run the panel behind Nginx/Apache with an SSL certificate.
 *   **SSH Keys**: Use SSH keys rather than passwords for connecting to your VPN servers.
 *   **Secret Key**: Set a custom `SECRET_KEY` environment variable for secure session management.
+*   **IPv6**: if your servers have global IPv6 but Docker is IPv4-only, leave `AWG_IPV6` at `auto` — the panel probes the container and keeps tunnels IPv4-only rather than blackholing client IPv6. Set `AWG_IPV6=off` to disable dual-stack everywhere.
 *   **API Tokens**: Treat each token like a password — store it in your integration's secret manager. Revoke it from `/settings` if it leaks or the integration is decommissioned. Rotate periodically; tokens inherit admin rights.
 
 ## 🤝 Contributing

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -21,6 +21,13 @@ from cryptography.hazmat.primitives import serialization
 
 logger = logging.getLogger(__name__)
 
+# Dual-stack behaviour for AWG tunnels, overridable like the panel's other
+# environment knobs (SECRET_KEY, TUNNEL_BIN_DIR): "auto" probes the server,
+# "off" keeps every tunnel IPv4-only, "on" forces dual-stack.
+AWG_IPV6_ENV = 'AWG_IPV6'
+IPV6_FORCE_OFF = ('off', 'false', '0', 'no', 'disable', 'disabled')
+IPV6_FORCE_ON = ('on', 'true', '1', 'yes', 'force', 'forced')
+
 # Default AWG parameters (from protocols_defs.h)
 AWG_DEFAULTS = {
     'port': '55424',
@@ -357,13 +364,51 @@ class AWGManager:
         prefix = gateway.rsplit(':', 1)[0] + ':'
         return f"{prefix}{octet:x}"
 
-    def _detect_server_ipv6(self):
-        """Check if the host has working IPv6 (default route or any global address)."""
+    def _detect_server_ipv6(self, protocol_type=None):
+        """Decide whether the tunnel should be dual-stack.
+
+        The AWG_IPV6 environment variable forces the answer ("off" / "on");
+        in the default "auto" mode the server is probed.
+
+        Auto-detection requires IPv6 to work end-to-end: a global address on
+        the host *and* a default IPv6 route inside the protocol container.
+        Docker networks are IPv4-only unless the daemon is explicitly
+        configured for IPv6, so checking the host alone can enable a
+        dual-stack tunnel whose NAT66 has nowhere to forward. Clients then
+        receive an IPv6 address, an IPv6 DNS server and ::/0 with no route
+        out, which blackholes traffic on IPv6-preferring clients (notably
+        macOS) even though the host's own IPv6 is fine.
+        """
+        mode = os.environ.get(AWG_IPV6_ENV, 'auto').strip().lower()
+        if mode in IPV6_FORCE_OFF:
+            logger.info("%s=%s, keeping the tunnel IPv4-only", AWG_IPV6_ENV, mode)
+            return False
+        if mode in IPV6_FORCE_ON:
+            logger.info("%s=%s, forcing a dual-stack tunnel", AWG_IPV6_ENV, mode)
+            return True
+
         out, _, _ = self.ssh.run_sudo_command("ip -6 route show default 2>/dev/null")
+        if not out.strip():
+            out, _, _ = self.ssh.run_sudo_command("ip -6 addr show scope global 2>/dev/null")
+            if not out.strip():
+                return False
+
+        if protocol_type is None:
+            return True
+
+        container_name = self._container_name(protocol_type)
+        out, _, _ = self.ssh.run_sudo_command(
+            f"docker exec {container_name} ip -6 route show default 2>/dev/null"
+        )
         if out.strip():
             return True
-        out, _, _ = self.ssh.run_sudo_command("ip -6 addr show scope global 2>/dev/null")
-        return bool(out.strip())
+
+        logger.info(
+            "Host has IPv6 but container %s has no IPv6 default route "
+            "(Docker IPv6 is disabled), keeping the tunnel IPv4-only",
+            container_name,
+        )
+        return False
 
     # ===================== INSTALLATION =====================
 
@@ -547,11 +592,11 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
 
         # Step 6: Configure container (generate server keys and config)
         results.append("Configuring AWG...")
-        ipv6_enabled = self._detect_server_ipv6()
+        ipv6_enabled = self._detect_server_ipv6(protocol_type)
         results.append(
-            "IPv6 detected on host, enabling dual-stack tunnel"
+            "IPv6 works end-to-end, enabling dual-stack tunnel"
             if ipv6_enabled else
-            "No IPv6 on host, tunnel will be IPv4-only"
+            "No usable IPv6 (host or Docker), tunnel will be IPv4-only"
         )
         self._configure_container(protocol_type, port, awg_params, ipv6=ipv6_enabled)
         results.append("AWG configured")
@@ -1315,12 +1360,17 @@ AllowedIPs = {allowed_ips}
                     continue
                 config_lines.append(f"{config_key} = {val}")
 
+        # Route ::/0 only when the client actually holds an IPv6 address:
+        # claiming the IPv6 default route on an IPv4-only tunnel blackholes
+        # the client's own native IPv6.
+        peer_allowed_ips = "0.0.0.0/0, ::/0" if client_ipv6 else "0.0.0.0/0"
+
         client_config = "[Interface]\n" + "\n".join(config_lines) + f"""
 
 [Peer]
 PublicKey = {server_pub_key}
 PresharedKey = {psk}
-AllowedIPs = 0.0.0.0/0, ::/0
+AllowedIPs = {peer_allowed_ips}
 Endpoint = {server_host}:{port}
 PersistentKeepalive = 25
 """
@@ -1407,12 +1457,15 @@ PersistentKeepalive = 25
                     continue
                 config_lines.append(f"{config_key} = {val}")
 
+        # See the client-creation path: ::/0 only on dual-stack tunnels.
+        peer_allowed_ips = "0.0.0.0/0, ::/0" if client_ipv6 else "0.0.0.0/0"
+
         config = "[Interface]\n" + "\n".join(config_lines) + f"""
 
 [Peer]
 PublicKey = {server_pub_key}
 PresharedKey = {psk}
-AllowedIPs = 0.0.0.0/0, ::/0
+AllowedIPs = {peer_allowed_ips}
 Endpoint = {server_host}:{port}
 PersistentKeepalive = 25
 """


### PR DESCRIPTION
# Keep AWG tunnels IPv4-only unless IPv6 works end-to-end

## Problem

`_detect_server_ipv6()` enables a dual-stack tunnel whenever the **host** has a global IPv6 address or a default IPv6 route. But Docker networks are IPv4-only unless the daemon is explicitly configured for IPv6 (`daemon.json` with `"ipv6": true`), which is the default on a stock install.

On such a server the install still goes ahead:

- the interface gets `Address = 10.8.1.1/24, fd42:8:1::1/64`
- NAT66 (`ip6tables MASQUERADE fd42:8:1::/64`) is configured, but the container has **no IPv6 default route** and no global IPv6 on `eth0` — there is nowhere to forward
- every client then receives `Address = 10.8.1.N/32, fd42:8:1::N/128`, `DNS = ..., 2606:4700:4700::1111` and `AllowedIPs = 0.0.0.0/0, ::/0`

So clients are handed an IPv6 address, an IPv6 DNS server and the IPv6 default route into a tunnel that cannot carry IPv6. Everything IPv6 blackholes.

Observed on a server whose host IPv6 works fine:

```
# on the host
$ ip -6 addr show scope global
    inet6 2a01:e5c0:xxxx::2/48 scope global
$ curl -6 https://api6.ipify.org
2a01:e5c0:xxxx::2                      # host IPv6 is fine

# inside the protocol container
$ docker exec amnezia-awg3 ip -6 route show default
                                       # empty — no IPv6 route
$ docker exec amnezia-awg3 curl -6 --max-time 6 https://api6.ipify.org
                                       # fails
```

The user-visible symptom is confusing: the same config **works** on a phone on a mobile network (carrier hands out no IPv6, so everything goes over IPv4) but **connects and then passes no traffic** on macOS, which prefers IPv6 once the interface has an IPv6 address — and the IPv6 DNS server makes even name resolution fail. It reads as "the config is broken" when the tunnel is fine and only the address family is wrong.

## Changes

1. **Probe the container, not just the host.** `_detect_server_ipv6()` now also requires a default IPv6 route *inside the protocol container* before enabling dual-stack. Called with `protocol_type` from `install_protocol()`; calling it without the argument keeps the previous host-only behaviour, so no other call site changes.

2. **A native `AWG_IPV6` knob**, in the same style as the panel's existing `SECRET_KEY` / `TUNNEL_BIN_DIR` environment variables:
   - `auto` (default) — probe as described above
   - `off` — keep every tunnel IPv4-only
   - `on` — force dual-stack (for admins who know their Docker IPv6 works)

3. **`::/0` only for dual-stack clients.** The client `[Peer] AllowedIPs` was hardcoded to `0.0.0.0/0, ::/0` in both the create and rebuild paths, even when the client had no IPv6 address at all. An IPv4-only tunnel claiming the IPv6 default route breaks the client's *own* native IPv6 for no reason. It now mirrors the `Address`/`DNS` lines, which were already conditional.

`README.md` documents the knob under the protocol list and in Security Recommendations.

## Compatibility

- No config-format or migration changes; nothing is written differently on servers where IPv6 genuinely works end-to-end.
- Existing dual-stack installs keep working — the detector only runs on install.
- Servers with no IPv6 at all behave exactly as before.
- `_detect_server_ipv6()` keeps its old signature via a default argument.

## Testing

`py_compile` clean. Behavioural check of the detector against a stubbed SSH layer, covering the override and every auto-detect branch:

```
PASS  AWG_IPV6=off forces IPv4-only
PASS  AWG_IPV6=disabled forces IPv4-only
PASS  AWG_IPV6=on forces dual-stack
PASS  auto: no IPv6 on host -> IPv4-only
PASS  auto: host IPv6 but container has none -> IPv4-only (the bug)
PASS  auto: IPv6 end-to-end -> dual-stack
PASS  auto: legacy call without protocol_type keeps old behaviour

7/7 passed
```

Verified on a live AWG 2.0 install: after removing the IPv6 parts from the server config, newly issued client configs come out `Address = 10.8.1.4/32` / `DNS = 1.1.1.1, 1.0.0.1` — and with this patch `AllowedIPs` follows suit as `0.0.0.0/0` instead of still carrying `::/0`.
