### PR TITLE
Add substring search to the assign-to-user picker

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -671,6 +671,92 @@ a:hover {
     cursor: pointer;
 }
 
+/* ===== Searchable Select ===== */
+.searchable-select {
+    position: relative;
+}
+
+/* The native <select> stays in the DOM as the source of truth. */
+.searchable-select-native {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.searchable-select-trigger {
+    display: block;
+    text-align: start;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.searchable-select.is-open .searchable-select-trigger {
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 3px var(--accent-glow);
+    background: var(--bg-secondary);
+}
+
+.searchable-select-panel {
+    position: absolute;
+    inset-inline: 0;
+    top: calc(100% + 4px);
+    z-index: 20;
+    padding: var(--space-sm);
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+}
+
+.searchable-select-search {
+    margin-bottom: var(--space-sm);
+}
+
+.searchable-select-search .form-input {
+    padding: 8px 12px;
+}
+
+.searchable-select-list {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.searchable-select-option {
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+
+.searchable-select-option:hover,
+.searchable-select-option.is-active {
+    background: var(--bg-card-hover);
+}
+
+.searchable-select-option[aria-selected="true"] {
+    color: var(--text-accent);
+}
+
+.searchable-select-option.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.searchable-select-empty {
+    padding: 8px 12px;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
 .form-row {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/static/js/searchable-select.js
+++ b/static/js/searchable-select.js
@@ -42,6 +42,10 @@
         trigger.type = 'button';
         trigger.className = 'form-select searchable-select-trigger';
         trigger.setAttribute('aria-haspopup', 'listbox');
+        // Option text is user data (names, emails) and may run counter to the
+        // page direction; let the browser pick per string instead of forcing
+        // the UI direction onto it.
+        trigger.setAttribute('dir', 'auto');
         trigger.setAttribute('aria-expanded', 'false');
         if (select.id) {
             trigger.setAttribute('aria-labelledby', select.id + '-label');
@@ -59,6 +63,7 @@
         search.className = 'form-input';
         search.autocomplete = 'off';
         search.spellcheck = false;
+        search.setAttribute('dir', 'auto');
         search.placeholder = select.dataset.searchPlaceholder || 'Search...';
         search.setAttribute('aria-controls', this.id + '-list');
         searchWrap.appendChild(search);
@@ -130,6 +135,7 @@
             var item = document.createElement('div');
             item.className = 'searchable-select-option';
             item.setAttribute('role', 'option');
+            item.setAttribute('dir', 'auto');
             item.id = self.id + '-opt-' + index;
             item.textContent = textOf(option);   // textContent: never trust option text as HTML
             item.dataset.index = String(index);

--- a/static/js/searchable-select.js
+++ b/static/js/searchable-select.js
@@ -1,0 +1,302 @@
+/**
+ * Searchable select — progressive enhancement for long <select> lists.
+ *
+ * Any `<select data-searchable>` is wrapped in a filterable dropdown: a
+ * trigger button styled like .form-select, a search box and a filtered
+ * option list with keyboard navigation.
+ *
+ * The original <select> stays in the DOM (visually hidden) and remains the
+ * single source of truth, so existing code that reads `.value`, sets it, or
+ * listens for `change` keeps working untouched.
+ *
+ * Labels come from data attributes so translations stay in the templates:
+ *   data-search-placeholder="..."   search box placeholder
+ *   data-search-empty="..."         shown when nothing matches
+ */
+(function () {
+    'use strict';
+
+    var ID_SEQ = 0;
+
+    function textOf(option) {
+        return (option.textContent || '').trim();
+    }
+
+    function SearchableSelect(select) {
+        this.select = select;
+        this.id = 'ss-' + (++ID_SEQ);
+        this.open = false;
+        this.activeIndex = -1;
+        this.items = [];
+        this.build();
+    }
+
+    SearchableSelect.prototype.build = function () {
+        var self = this;
+        var select = this.select;
+
+        var wrapper = document.createElement('div');
+        wrapper.className = 'searchable-select';
+
+        var trigger = document.createElement('button');
+        trigger.type = 'button';
+        trigger.className = 'form-select searchable-select-trigger';
+        trigger.setAttribute('aria-haspopup', 'listbox');
+        trigger.setAttribute('aria-expanded', 'false');
+        if (select.id) {
+            trigger.setAttribute('aria-labelledby', select.id + '-label');
+        }
+
+        var panel = document.createElement('div');
+        panel.className = 'searchable-select-panel';
+        panel.hidden = true;
+
+        var searchWrap = document.createElement('div');
+        searchWrap.className = 'searchable-select-search';
+
+        var search = document.createElement('input');
+        search.type = 'text';
+        search.className = 'form-input';
+        search.autocomplete = 'off';
+        search.spellcheck = false;
+        search.placeholder = select.dataset.searchPlaceholder || 'Search...';
+        search.setAttribute('aria-controls', this.id + '-list');
+        searchWrap.appendChild(search);
+
+        var list = document.createElement('div');
+        list.className = 'searchable-select-list';
+        list.id = this.id + '-list';
+        list.setAttribute('role', 'listbox');
+
+        var empty = document.createElement('div');
+        empty.className = 'searchable-select-empty';
+        empty.textContent = select.dataset.searchEmpty || 'No matches';
+        empty.hidden = true;
+
+        panel.appendChild(searchWrap);
+        panel.appendChild(list);
+        panel.appendChild(empty);
+
+        select.parentNode.insertBefore(wrapper, select);
+        wrapper.appendChild(select);
+        wrapper.appendChild(trigger);
+        wrapper.appendChild(panel);
+        select.classList.add('searchable-select-native');
+        select.setAttribute('tabindex', '-1');
+        select.setAttribute('aria-hidden', 'true');
+
+        this.wrapper = wrapper;
+        this.trigger = trigger;
+        this.panel = panel;
+        this.search = search;
+        this.list = list;
+        this.empty = empty;
+
+        this.renderOptions();
+        this.syncTrigger();
+
+        trigger.addEventListener('click', function () {
+            self.toggle();
+        });
+        trigger.addEventListener('keydown', function (e) {
+            if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                self.show();
+            }
+        });
+        search.addEventListener('input', function () {
+            self.filter(search.value);
+        });
+        search.addEventListener('keydown', function (e) {
+            self.onSearchKey(e);
+        });
+        select.addEventListener('change', function () {
+            self.syncTrigger();
+        });
+        document.addEventListener('click', function (e) {
+            if (self.open && !wrapper.contains(e.target)) {
+                self.hide();
+            }
+        });
+    };
+
+    /** Rebuild the option list from the native <select>. */
+    SearchableSelect.prototype.renderOptions = function () {
+        var self = this;
+        this.list.textContent = '';
+        this.items = [];
+
+        Array.prototype.forEach.call(this.select.options, function (option, index) {
+            var item = document.createElement('div');
+            item.className = 'searchable-select-option';
+            item.setAttribute('role', 'option');
+            item.id = self.id + '-opt-' + index;
+            item.textContent = textOf(option);   // textContent: never trust option text as HTML
+            item.dataset.index = String(index);
+            if (option.disabled) {
+                item.classList.add('is-disabled');
+            }
+            item.addEventListener('click', function () {
+                if (option.disabled) return;
+                self.choose(index);
+            });
+            self.list.appendChild(item);
+            self.items.push({ el: item, text: textOf(option).toLowerCase(), index: index });
+        });
+    };
+
+    SearchableSelect.prototype.syncTrigger = function () {
+        var option = this.select.options[this.select.selectedIndex];
+        this.trigger.textContent = option ? textOf(option) : '';
+        var self = this;
+        this.items.forEach(function (item) {
+            item.el.setAttribute('aria-selected', item.index === self.select.selectedIndex ? 'true' : 'false');
+        });
+    };
+
+    SearchableSelect.prototype.filter = function (query) {
+        var needle = (query || '').trim().toLowerCase();
+        var visible = 0;
+        this.items.forEach(function (item) {
+            var match = !needle || item.text.indexOf(needle) !== -1;
+            item.el.hidden = !match;
+            if (match) visible++;
+        });
+        this.empty.hidden = visible !== 0;
+        this.setActive(this.firstVisibleIndex());
+    };
+
+    SearchableSelect.prototype.visibleItems = function () {
+        return this.items.filter(function (item) {
+            return !item.el.hidden && !item.el.classList.contains('is-disabled');
+        });
+    };
+
+    SearchableSelect.prototype.firstVisibleIndex = function () {
+        var visible = this.visibleItems();
+        return visible.length ? visible[0].index : -1;
+    };
+
+    SearchableSelect.prototype.setActive = function (index) {
+        var self = this;
+        this.activeIndex = index;
+        this.items.forEach(function (item) {
+            var active = item.index === index;
+            item.el.classList.toggle('is-active', active);
+            if (active) {
+                self.list.setAttribute('aria-activedescendant', item.el.id);
+                var top = item.el.offsetTop;
+                var bottom = top + item.el.offsetHeight;
+                if (top < self.list.scrollTop) {
+                    self.list.scrollTop = top;
+                } else if (bottom > self.list.scrollTop + self.list.clientHeight) {
+                    self.list.scrollTop = bottom - self.list.clientHeight;
+                }
+            }
+        });
+        if (index === -1) {
+            this.list.removeAttribute('aria-activedescendant');
+        }
+    };
+
+    SearchableSelect.prototype.moveActive = function (step) {
+        var visible = this.visibleItems();
+        if (!visible.length) return;
+        var current = -1;
+        for (var i = 0; i < visible.length; i++) {
+            if (visible[i].index === this.activeIndex) { current = i; break; }
+        }
+        var next = current + step;
+        if (next < 0) next = visible.length - 1;
+        if (next >= visible.length) next = 0;
+        this.setActive(visible[next].index);
+    };
+
+    SearchableSelect.prototype.onSearchKey = function (e) {
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                this.moveActive(1);
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                this.moveActive(-1);
+                break;
+            case 'Enter':
+                e.preventDefault();
+                if (this.activeIndex !== -1) this.choose(this.activeIndex);
+                break;
+            case 'Escape':
+                e.preventDefault();
+                this.hide();
+                this.trigger.focus();
+                break;
+            case 'Tab':
+                this.hide();
+                break;
+        }
+    };
+
+    SearchableSelect.prototype.choose = function (index) {
+        this.select.selectedIndex = index;
+        this.select.dispatchEvent(new Event('input', { bubbles: true }));
+        this.select.dispatchEvent(new Event('change', { bubbles: true }));
+        this.syncTrigger();
+        this.hide();
+        this.trigger.focus();
+    };
+
+    SearchableSelect.prototype.show = function () {
+        if (this.open) return;
+        this.open = true;
+        this.panel.hidden = false;
+        this.wrapper.classList.add('is-open');
+        this.trigger.setAttribute('aria-expanded', 'true');
+        this.syncTrigger();               // pick up programmatic value changes
+        this.search.value = '';
+        this.filter('');
+        this.setActive(this.select.selectedIndex);
+        this.search.focus();
+    };
+
+    SearchableSelect.prototype.hide = function () {
+        if (!this.open) return;
+        this.open = false;
+        this.panel.hidden = true;
+        this.wrapper.classList.remove('is-open');
+        this.trigger.setAttribute('aria-expanded', 'false');
+    };
+
+    SearchableSelect.prototype.toggle = function () {
+        this.open ? this.hide() : this.show();
+    };
+
+    /** Re-read options from the native select (call after changing them). */
+    SearchableSelect.prototype.refresh = function () {
+        this.renderOptions();
+        this.syncTrigger();
+        if (this.open) this.filter(this.search.value);
+    };
+
+    function enhance(select) {
+        if (!select || select.searchableSelect) return null;
+        select.searchableSelect = new SearchableSelect(select);
+        return select.searchableSelect;
+    }
+
+    function enhanceAll(root) {
+        var scope = root || document;
+        Array.prototype.forEach.call(
+            scope.querySelectorAll('select[data-searchable]'),
+            enhance
+        );
+    }
+
+    window.SearchableSelect = { enhance: enhance, enhanceAll: enhanceAll };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () { enhanceAll(); });
+    } else {
+        enhanceAll();
+    }
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <script>!function () { var t = localStorage.getItem('theme') || 'dark'; document.documentElement.setAttribute('data-theme', t) }()</script>
     <script src="/static/js/qrcode.min.js"></script>
+    <script src="/static/js/searchable-select.js" defer></script>
     {% block head_extra %}{% endblock %}
     <style>
         .lang-check {

--- a/templates/server.html
+++ b/templates/server.html
@@ -811,7 +811,9 @@
 
         <div class="form-group">
             <label class="form-label">{{ _('assign_to_user') }}</label>
-            <select class="form-select" id="connectionUserId">
+            <select class="form-select" id="connectionUserId" data-searchable
+                data-search-placeholder="{{ _('select_search_placeholder') }}"
+                data-search-empty="{{ _('select_search_empty') }}">
                 <option value="">{{ _('no_assign') }}</option>
                 {% for u in users %}
                 <option value="{{ u.id }}">{{ u.username }} ({{ u.role }})</option>

--- a/translations/en.json
+++ b/translations/en.json
@@ -96,6 +96,8 @@
   "connection_name_placeholder": "Example: iPhone, Laptop",
   "assign_to_user": "Assign to user (optional)",
   "no_assign": "— No assignment —",
+  "select_search_placeholder": "Search...",
+  "select_search_empty": "No matches",
   "create": "Create",
   "creating": "Creating...",
   "connection_created": "Connection \"{}\" created",

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -95,6 +95,8 @@
   "connection_name_placeholder": "مثال: iPhone, Laptop",
   "assign_to_user": "تخصیص به کاربر (اختیاری)",
   "no_assign": "— بدون تخصیص —",
+  "select_search_placeholder": "جستجو...",
+  "select_search_empty": "موردی یافت نشد",
   "create": "ایجاد",
   "creating": "در حال ایجاد...",
   "connection_created": "اتصال \"{}\" ایجاد شد",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -95,6 +95,8 @@
   "connection_name_placeholder": "Ex: iPhone, Laptop",
   "assign_to_user": "Assigner à l'utilisateur (optionnel)",
   "no_assign": "— Aucune assignation —",
+  "select_search_placeholder": "Rechercher...",
+  "select_search_empty": "Aucun résultat",
   "create": "Créer",
   "creating": "Création...",
   "connection_created": "Connexion \"{}\" créée",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -96,6 +96,8 @@
   "connection_name_placeholder": "Например: iPhone, Laptop",
   "assign_to_user": "Назначить пользователю (опционально)",
   "no_assign": "— Без привязки —",
+  "select_search_placeholder": "Поиск...",
+  "select_search_empty": "Ничего не найдено",
   "create": "Создать",
   "creating": "Создание...",
   "connection_created": "Подключение \"{}\" создано",

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -95,6 +95,8 @@
   "connection_name_placeholder": "例如: iPhone, 笔记本电脑",
   "assign_to_user": "分配给用户 (可选)",
   "no_assign": "— 不分配 —",
+  "select_search_placeholder": "搜索...",
+  "select_search_empty": "无匹配项",
   "create": "创建",
   "creating": "创建中...",
   "connection_created": "连接 \"{}\" 已创建",


### PR DESCRIPTION
# Add substring search to the "assign to user" picker

## Problem

When creating a connection, the **Assign to user** field in the Add Connection modal is a plain `<select>` listing every user on the panel. With a few dozen users that means scrolling and reading each entry — there's no way to just type a name. Native select typeahead only jumps to entries that *start* with what you type, which doesn't help when users are named `alice@example.com (user)` and you remember the domain or the surname.

## What this does

Adds a small, dependency-free searchable select and applies it to that field. Click the field and you get a search box: type any substring, the list filters as you go, arrow keys and Enter pick an entry.

It's **progressive enhancement**, not a replacement. The native `<select>` stays in the DOM as the single source of truth, so everything that touches it keeps working unchanged:

- `document.getElementById('connectionUserId').value` — read in `server.html` when submitting — is untouched
- setting `.value` programmatically updates the visible label
- `change` / `input` events still fire, once, with the same semantics

If the script fails to load for any reason, the original `<select>` is still there and fully usable.

## Implementation

- **`static/js/searchable-select.js`** — opt-in via a `data-searchable` attribute on any `<select>`, so other long lists can use it later. Case-insensitive substring filtering, keyboard navigation (`↑`/`↓`/`Enter`/`Escape`/`Tab`), an empty state, click-outside to close, and ARIA combobox/listbox roles with `aria-activedescendant`. Option text is written with `textContent`, never `innerHTML`.
- **`static/css/style.css`** — styles built entirely from the existing design tokens (`--bg-card`, `--border-focus`, `--text-accent`, `--radius-*`, …), so light/dark themes and RTL follow the rest of the panel with no extra rules. The panel is `position: absolute` and width-matched to the field, so it stays inside the modal.
- **`templates/server.html`** — marks the one select, passing labels as `data-search-*` attributes so strings stay in the templates (the project has no JS-side i18n).
- **`translations/*.json`** — two new keys (`select_search_placeholder`, `select_search_empty`) added to all five locales: en, ru, fr, fa, zh.

## Why not select2

The panel currently ships no jQuery — the only bundled script is `qrcode.min.js`. select2 would mean adding jQuery plus select2 (~160 KB together) and then restyling it to match the panel's CSS variables for both themes and RTL. That seemed a poor trade against ~300 lines of vanilla JS with no build step and no new supply-chain surface. Happy to switch if you'd rather have the library.

## Testing

Exercised in a browser against a 56-user list (matching the real `username (role)` option format), in dark, light and RTL:

| Check | Result |
|---|---|
| Component initialises, native `<select>` kept in DOM | pass |
| Substring filter (`zharkova` → 8 of 57) | pass |
| Case-insensitive, matches mid-string (`HARKOV`) | pass |
| Empty state on no match | pass |
| Click selects → native `.value`, label and `change` all sync (fired once) | pass |
| `↑`/`↓` move the active option, `Enter` selects | pass |
| `Escape` closes and returns focus to the trigger | pass |
| Programmatic `.value` change reflected in the label | pass |
| Light theme: colours resolve identically to a native `.form-input` | pass |
| RTL: panel aligned to the field, inside the modal, filtering works | pass |

Screenshots aren't included because the check ran in a headless pane, but every assertion above was made against computed styles and live DOM state rather than by eye.
