### PR TITLE
feat: per-peer speed limit (Mbps, step 0.1, 0 = unlimited) for AmneziaWG

### DIFF
--- a/app.py
+++ b/app.py
@@ -1530,6 +1530,7 @@ class RenameConnectionRequest(BaseModel):
     protocol: str = 'awg'
     client_id: str = ''
     new_name: str = ''
+    max_speed: float = -1  # Mbit/s; -1 = don't touch, 0 = unlimited
 
 class SaveConnectionConfigRequest(BaseModel):
     protocol: str = 'awg'
@@ -3253,6 +3254,14 @@ async def api_rename_connection(request: Request, server_id: int, req: RenameCon
         ssh.connect()
         manager = get_protocol_manager(ssh, req.protocol)
         result = _manager_call(manager, 'rename_client', req.protocol, req.client_id, new_name) or {}
+        # Optional per-peer bandwidth limit (managers exposing set_speed_limit)
+        speed_warning = None
+        if req.max_speed >= 0 and hasattr(manager, 'set_speed_limit'):
+            try:
+                _manager_call(manager, 'set_speed_limit', req.protocol, req.client_id, req.max_speed)
+            except Exception as se:
+                logger.warning(f"set_speed_limit failed: {se}")
+                speed_warning = str(se)
         ssh.disconnect()
         # Telemt rename may also change client_id (username is the identity there)
         new_client_id = result.get('client_id', req.client_id)
@@ -3265,7 +3274,10 @@ async def api_rename_connection(request: Request, server_id: int, req: RenameCon
                 changed = True
         if changed:
             save_data(data)
-        return {'status': 'success', 'name': stored_name, 'client_id': new_client_id}
+        resp = {'status': 'success', 'name': stored_name, 'client_id': new_client_id}
+        if speed_warning:
+            resp['speed_warning'] = speed_warning
+        return resp
     except Exception as e:
         logger.exception("Error renaming connection")
         return JSONResponse({'error': str(e)}, status_code=500)

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -748,6 +748,13 @@ if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
   ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
 fi
 
+# Apply per-peer bandwidth limits (flat file written by the panel)
+if [ -f /opt/amnezia/awg/bwlimits ]; then
+(
+{self._tc_apply_body('/opt/amnezia/awg/bwlimits', config_path)}
+)
+fi
+
 tail -f /dev/null
 """
 
@@ -813,6 +820,106 @@ tail -f /dev/null
             f"docker cp /tmp/_amnz_clients.json {container_name}:{clients_table_path}"
         )
         self.ssh.run_command("rm -f /tmp/_amnz_clients.json")
+
+        # Keep per-peer bandwidth limits in sync (best effort)
+        try:
+            self._apply_bw_limits(protocol_type, clients_table)
+        except Exception as err:
+            logger.warning(f"apply bw limits warning: {err}")
+
+    def _bwlimits_path(self):
+        """Flat file with per-peer speed limits, next to clientsTable."""
+        return '/opt/amnezia/awg/bwlimits'
+
+    @staticmethod
+    def _tc_apply_body(bw_path, config_path):
+        """Shell snippet applying per-peer limits from a flat file via tc.
+
+        File format (space separated): "<ipv4> <ipv6|-> <mbps>".
+        Rebuilds qdiscs from scratch; unclassified traffic is unlimited.
+        Limits both download (HTB class on egress) and upload (ingress policer).
+        """
+        return f"""
+BW={bw_path}
+IFACE=$(basename {config_path} .conf)
+[ -f "$BW" ] || exit 0
+command -v tc >/dev/null 2>&1 || exit 0
+ip link show dev $IFACE >/dev/null 2>&1 || exit 0
+tc qdisc del dev $IFACE root 2>/dev/null
+tc qdisc del dev $IFACE ingress 2>/dev/null
+tc qdisc add dev $IFACE root handle 1: htb default 0 2>/dev/null || exit 0
+tc qdisc add dev $IFACE handle ffff: ingress 2>/dev/null || true
+i=0
+while read -r ip4 ip6 mbps; do
+  [ -z "$ip4" ] && continue
+  [ -z "$mbps" ] && continue
+  kbit=$(echo "$mbps" | awk '{{printf "%d", $1*1000}}')
+  [ "$kbit" -gt 0 ] 2>/dev/null || continue
+  i=$((i+1))
+  cid=$((100+i))
+  tc class add dev $IFACE parent 1: classid 1:$cid htb rate ${{kbit}}kbit ceil ${{kbit}}kbit 2>/dev/null
+  tc filter add dev $IFACE parent 1: protocol ip u32 match ip dst $ip4/32 flowid 1:$cid 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent 1: protocol ipv6 u32 match ip6 dst $ip6/128 flowid 1:$cid 2>/dev/null
+  tc filter add dev $IFACE parent ffff: protocol ip u32 match ip src $ip4/32 police rate ${{kbit}}kbit burst 64k drop 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent ffff: protocol ipv6 u32 match ip6 src $ip6/128 police rate ${{kbit}}kbit burst 64k drop 2>/dev/null
+done < "$BW"
+"""
+
+    def _apply_bw_limits(self, protocol_type, clients_table):
+        """Write the flat bwlimits file into the container and apply via tc."""
+        container_name = self._container_name(protocol_type)
+        lines = []
+        for client in clients_table:
+            ud = client.get('userData', {}) or {}
+            try:
+                mbps = float(ud.get('maxSpeed') or 0)
+            except (TypeError, ValueError):
+                continue
+            if mbps <= 0:
+                continue
+            ip4 = ud.get('clientIp') or ''
+            ip6 = ud.get('clientIpv6') or '-'
+            if not ip4:
+                continue
+            lines.append(f"{ip4} {ip6} {mbps:g}")
+        content = "\n".join(lines) + ("\n" if lines else "")
+        self.ssh.upload_file(content, "/tmp/_amnz_bwlimits")
+        self.ssh.run_sudo_command(
+            f"docker cp /tmp/_amnz_bwlimits {container_name}:{self._bwlimits_path()}"
+        )
+        self.ssh.run_command("rm -f /tmp/_amnz_bwlimits")
+        if self.check_container_running(protocol_type):
+            body = self._tc_apply_body(self._bwlimits_path(), self._resolve_config_path(protocol_type))
+            self.ssh.upload_file(body, "/tmp/_amnz_tc.sh")
+            self.ssh.run_sudo_command(
+                f"docker cp /tmp/_amnz_tc.sh {container_name}:/tmp/_amnz_tc.sh && "
+                f"docker exec {container_name} bash /tmp/_amnz_tc.sh",
+                timeout=60
+            )
+            self.ssh.run_command("rm -f /tmp/_amnz_tc.sh")
+
+    def set_speed_limit(self, protocol_type, client_id, max_speed):
+        """Set per-peer bandwidth limit in Mbit/s (0 = unlimited).
+
+        Enforced via tc inside the container (HTB on egress + ingress
+        policer), per peer IPv4/IPv6. Persisted in clientsTable
+        (userData.maxSpeed) and re-applied at container start from the
+        bwlimits flat file.
+        """
+        mbps = round(float(max_speed), 1)
+        if mbps < 0:
+            raise RuntimeError('max_speed must be >= 0')
+        clients_table = self._get_clients_table(protocol_type)
+        client = next((c for c in clients_table if c.get('clientId') == client_id), None)
+        if client is None:
+            raise RuntimeError('Client not found')
+        ud = client.setdefault('userData', {})
+        if mbps == 0:
+            ud.pop('maxSpeed', None)
+        else:
+            ud['maxSpeed'] = mbps
+        self._save_clients_table(protocol_type, clients_table)
+        return {'status': 'success', 'max_speed': mbps}
 
     def _get_server_config(self, protocol_type):
         """Get the server WireGuard config."""
@@ -899,6 +1006,13 @@ if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
   ip6tables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
   ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth0 -j MASQUERADE
   ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
+fi
+
+# Apply per-peer bandwidth limits (flat file written by the panel)
+if [ -f /opt/amnezia/awg/bwlimits ]; then
+(
+{self._tc_apply_body('/opt/amnezia/awg/bwlimits', config_path)}
+)
 fi
 
 tail -f /dev/null

--- a/templates/server.html
+++ b/templates/server.html
@@ -2070,6 +2070,10 @@
                 if (assignedUser) metaHtml += `<span class="badge badge-info" style="font-size:0.65rem;">👤 ${escapeHtml(assignedUser)}</span>`;
                 if (created) metaHtml += `<span>📅 ${formatDate(created)}</span>`;
 
+                // Per-peer bandwidth limit badge (AWG): ∞ by default, ⚡X Mbps when set
+                const maxSpeed = parseFloat(userData.maxSpeed || 0) || 0;
+                if (proto.startsWith('awg')) metaHtml += `<span class="traffic-badge" title="${_('max_speed')}">⚡${maxSpeed > 0 ? maxSpeed + ' Mbps' : '∞'}</span>`;
+
                 if (proto === 'telemt') {
                     if (userData.total_octets) metaHtml += `<span class="traffic-badge">📊 ${formatBytes(userData.total_octets)}</span>`;
                     if (userData.current_connections !== undefined) metaHtml += `<span>🔌 ${userData.current_connections} conns</span>`;
@@ -2094,7 +2098,7 @@
                 const canShowConfig = proto === 'xray' || true; // always show 📄 button
 
                 listEl.innerHTML += `
-                    <div class="client-item" style="${disabledStyle}">
+                    <div class="client-item" style="${disabledStyle}" data-maxspeed="${maxSpeed}">
                         <div class="client-info">
                             <div class="client-avatar${client._online ? ' avatar-online' : ''}">${initial}</div>
                             <div>
@@ -2243,27 +2247,43 @@
         const item = btn.closest('.client-item');
         const nameEl = item.querySelector('.client-name');
         const oldName = nameEl.textContent;
+        const proto = document.getElementById('connProtoSelect').value;
+        const isAwg = proto.startsWith('awg');
+        const curSpeed = item.dataset.maxspeed || '0';
         nameEl.innerHTML = `
-            <span class="rename-editor" style="display:inline-flex;gap:4px;align-items:center;">
-                <input type="text" class="form-input" style="padding:2px 8px;font-size:0.85rem;width:160px;height:auto;" value="${escapeHtml(oldName)}">
+            <span class="rename-editor" style="display:inline-flex;gap:12px;align-items:flex-end;flex-wrap:wrap;">
+                <label style="display:flex;flex-direction:column;gap:2px;font-size:0.7rem;opacity:.7;">
+                    ${_('name')}
+                    <input type="text" class="form-input" style="padding:2px 8px;font-size:0.85rem;width:160px;height:auto;" value="${escapeHtml(oldName)}">
+                </label>
+                ${isAwg ? `<label style="display:flex;flex-direction:column;gap:2px;font-size:0.7rem;opacity:.7;">
+                    ${_('speed_limit_unlim')}
+                    <input type="number" class="form-input rename-speed" min="0" step="0.1" style="padding:2px 8px;font-size:0.85rem;width:110px;height:auto;" value="${curSpeed}" placeholder="∞">
+                </label>` : ''}
                 <button class="btn btn-secondary btn-sm btn-icon" title="${_('save')}">✔</button>
                 <button class="btn btn-secondary btn-sm btn-icon rename-cancel" title="${_('cancel')}">✖</button>
             </span>
         `;
         const input = nameEl.querySelector('input');
+        const speedInput = nameEl.querySelector('.rename-speed');
         const saveBtn = nameEl.querySelector('button:not(.rename-cancel)');
         const cancelBtn = nameEl.querySelector('.rename-cancel');
-        saveBtn.addEventListener('click', () => saveRenameConnection(clientId, input.value));
+        const doSave = () => saveRenameConnection(clientId, input.value, speedInput ? (parseFloat(speedInput.value) || 0) : -1);
+        saveBtn.addEventListener('click', doSave);
         cancelBtn.addEventListener('click', () => loadConnections());
         input.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') saveRenameConnection(clientId, input.value);
+            if (e.key === 'Enter') doSave();
+            if (e.key === 'Escape') loadConnections();
+        });
+        if (speedInput) speedInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') doSave();
             if (e.key === 'Escape') loadConnections();
         });
         input.focus();
         input.select();
     }
 
-    async function saveRenameConnection(clientId, rawName) {
+    async function saveRenameConnection(clientId, rawName, maxSpeed = -1) {
         const proto = document.getElementById('connProtoSelect').value;
         const newName = (rawName || '').trim();
         if (!newName) {
@@ -2272,9 +2292,13 @@
         }
         try {
             const result = await apiCall(`/api/servers/${SERVER_ID}/connections/rename`, 'POST', {
-                protocol: proto, client_id: clientId, new_name: newName,
+                protocol: proto, client_id: clientId, new_name: newName, max_speed: maxSpeed,
             });
-            showToast(_('connection_renamed'), 'success');
+            if (result.speed_warning) {
+                showToast(_('error') + ': ' + result.speed_warning, 'error');
+            } else {
+                showToast(_('connection_renamed'), 'success');
+            }
             // If the config modal is open for this connection, retitle it too.
             if (currentConfigClientId === clientId &&
                 document.getElementById('configModal').classList.contains('active')) {

--- a/templates/server.html
+++ b/templates/server.html
@@ -2072,7 +2072,7 @@
 
                 // Per-peer bandwidth limit badge (AWG): ∞ by default, ⚡X Mbps when set
                 const maxSpeed = parseFloat(userData.maxSpeed || 0) || 0;
-                if (proto.startsWith('awg')) metaHtml += `<span class="traffic-badge" title="${_('max_speed')}">⚡${maxSpeed > 0 ? maxSpeed + ' Mbps' : '∞'}</span>`;
+                if (proto.startsWith('awg')) metaHtml += `<span class="traffic-badge" title="${_('max_speed')}">⚡${maxSpeed > 0 ? maxSpeed + ' Mbps' : '<span style="font-size:1.25em; line-height:0;">∞</span>'}</span>`;
 
                 if (proto === 'telemt') {
                     if (userData.total_octets) metaHtml += `<span class="traffic-badge">📊 ${formatBytes(userData.total_octets)}</span>`;

--- a/translations/en.json
+++ b/translations/en.json
@@ -436,5 +436,7 @@
   "reset_traffic": "Reset traffic",
   "resetting": "Resetting...",
   "reset_traffic_confirm": "Reset this user's current traffic? Total statistics will be kept.",
-  "traffic_reset_success": "Traffic reset"
+  "traffic_reset_success": "Traffic reset",
+  "max_speed": "Max speed (Mbps)",
+  "speed_limit_unlim": "Speed limit (0 = unlim.)"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -403,5 +403,7 @@
   "reset_traffic": "بازنشانی ترافیک",
   "resetting": "در حال بازنشانی...",
   "reset_traffic_confirm": "ترافیک فعلی این کاربر بازنشانی شود؟ آمار کل حفظ میشود.",
-  "traffic_reset_success": "ترافیک بازنشانی شد"
+  "traffic_reset_success": "ترافیک بازنشانی شد",
+  "max_speed": "حداکثر سرعت (Mbps)",
+  "speed_limit_unlim": "محدودیت سرعت (0 = نامحدود)"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -403,5 +403,7 @@
   "reset_traffic": "Réinitialiser le trafic",
   "resetting": "Réinitialisation...",
   "reset_traffic_confirm": "Réinitialiser le trafic actuel de cet utilisateur ? Les statistiques totales seront conservées.",
-  "traffic_reset_success": "Trafic réinitialisé"
+  "traffic_reset_success": "Trafic réinitialisé",
+  "max_speed": "Vitesse max (Mbps)",
+  "speed_limit_unlim": "Limite de vitesse (0 = illimité)"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -436,5 +436,7 @@
   "reset_traffic": "Сбросить трафик",
   "resetting": "Сброс...",
   "reset_traffic_confirm": "Сбросить текущий трафик пользователя? Общая статистика сохранится.",
-  "traffic_reset_success": "Трафик сброшен"
+  "traffic_reset_success": "Трафик сброшен",
+  "max_speed": "Макс. скорость (Мбит/с)",
+  "speed_limit_unlim": "Лимит скорости (0 = без лимита)"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -403,5 +403,7 @@
   "reset_traffic": "重置流量",
   "resetting": "正在重置...",
   "reset_traffic_confirm": "重置此用户的当前流量？总统计将保留。",
-  "traffic_reset_success": "流量已重置"
+  "traffic_reset_success": "流量已重置",
+  "max_speed": "最大速度 (Mbps)",
+  "speed_limit_unlim": "速度限制（0 = 不限）"
 }


### PR DESCRIPTION
## Что добавляет PR

Возможность задать каждому пиру AmneziaWG индивидуальный лимит скорости в Мбит/с (шаг 0.1, `0` = без лимита).

### Как работает

- **`managers/awg_manager.py`** — новый метод `set_speed_limit()`:
  - egress: `tc qdisc htb` на интерфейсе `awg0`, класс с `rate`/`ceil` для IPv4 и IPv6 адреса пира
  - ingress: `tc qdisc ingress` + policer на пир-IP
  - лимиты сохраняются в flat-файл `bwlimits` рядом с `clientsTable` и автоматически применяются при старте контейнера (хук в `start.sh`)
  - применение вызывается из `_save_clients_table` — лимиты переживают добавление/удаление пиров и пересоздание интерфейса
- **Хранение** — `userData.maxSpeed` в `clientsTable`, как и остальные пользовательские поля пира
- **`app.py`** — `RenameConnectionRequest.max_speed` (float, `-1` = не менять); `api_rename_connection` применяет лимит через `set_speed_limit`, ошибки tc возвращаются как `speed_warning` в ответе (rename при этом не падает)
- **UI (`templates/server.html`)**:
  - бейдж `⚡∞ / ⚡X Mbps` на карточке пира (только для AWG-протоколов)
  - в диалоге переименования — поле скорости с подписями полей «Название» / «Лимит скорости (0 = без лимита)», `step=0.1`
- **Переводы**: en / ru / fr / fa / zh

### Совместимость

- `tc` присутствует в образе `amneziavpn/amneziawg-go` (проверено)
- Если менеджер не поддерживает `set_speed_limit` (кастомные сборки), панель молча пропускает (`hasattr`-проверка)
- Работает и на удалённых серверах: лимит применяется внутри контейнера инстанса по SSH

### Тест

Проверено на живом сервере (панель на одном хосте, инстанс AWG 2.0 на другом): установлен лимит 1 Мбит/с через UI → реальная скорость пира резалась до ~1 Мбит/с. Снятие лимита (0) восстанавливает полную скорость.