### PR TITLE
fix(ui): no protocol-cards flash on load; modals survive drag-select past the border

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -194,12 +194,21 @@
             }
         }
 
-        /* Close modal on backdrop click */
+        /* Close modal on backdrop click — but only when BOTH the press and
+           the release happen on the backdrop. Pressing inside the modal
+           (e.g. selecting input text) and releasing outside must not close
+           it, otherwise drag-select closes every modal. */
+        let backdropPressTarget = null;
+        document.addEventListener('mousedown', (e) => {
+            backdropPressTarget = e.target;
+        });
         document.addEventListener('click', (e) => {
-            if (e.target.classList.contains('modal-backdrop') && e.target.classList.contains('active')) {
+            if (e.target.classList.contains('modal-backdrop') && e.target.classList.contains('active')
+                && backdropPressTarget === e.target) {
                 e.target.classList.remove('active');
                 document.body.style.overflow = '';
             }
+            backdropPressTarget = null;
         });
 
         /* Close modal on Escape */

--- a/templates/server.html
+++ b/templates/server.html
@@ -73,6 +73,12 @@
     .protocol-card.installed-app-visible {
         display: block !important;
     }
+    /* While the status check runs, hide every protocol tile so the grid
+       does not flash the full marketplace list before real data arrives */
+    .protocol-cards.apps-pending .protocol-card,
+    .protocol-cards.apps-pending .promo-block {
+        display: none !important;
+    }
     .apps-loading {
         margin-bottom: var(--space-xl);
         min-height: 140px;
@@ -171,7 +177,7 @@
     </button>
 </div>
 
-<div class="protocol-cards" id="protocols-grid">
+<div class="protocol-cards apps-pending" id="protocols-grid">
     <!-- AWG3 Card (first - newest version).
          Installed-protocol tiles are static cards toggled by
          applyInstalledAppsVisibility(); a protocol without one is shown in the
@@ -1133,8 +1139,10 @@
         installedAppsLoading = !!isLoading;
         const loading = document.getElementById('installedAppsLoading');
         const empty = document.getElementById('installedAppsEmpty');
+        const grid = document.getElementById('protocols-grid');
         if (loading) loading.classList.toggle('hidden', !installedAppsLoading);
         if (empty && installedAppsLoading) empty.classList.add('hidden');
+        if (grid) grid.classList.toggle('apps-pending', installedAppsLoading);
     }
 
     function applyInstalledAppsVisibility() {
@@ -1195,6 +1203,7 @@
         if (empty) empty.classList.toggle('hidden', installedAppsLoading || installedCount > 0);
         const loading = document.getElementById('installedAppsLoading');
         if (loading) loading.classList.toggle('hidden', !installedAppsLoading);
+        if (grid) grid.classList.toggle('apps-pending', installedAppsLoading);
     }
 
     function getProtoTitle(proto) {


### PR DESCRIPTION
## Two small but annoying UI papercuts on the server page

### 1. Protocol cards flash before the status check finishes

When opening a server page, the static protocol tiles (AWG, Xray, SOCKS5, DNS, ...) render immediately, then the «Проверяем сервисы сервера...» spinner appears, and only when the status response arrives are the non-installed tiles hidden. The user sees the full marketplace list for a moment even though most of it isn't installed.

Fix: the grid gets an `apps-pending` class in the HTML that hides all tiles from the first frame; `setInstalledAppsLoading()` toggles it together with the spinner. While the check runs only the spinner is visible; when data arrives, exactly the installed cards appear.

### 2. Modals close when drag-selecting text past the modal edge

Press the mouse button inside a modal input, drag the cursor outside the modal while holding, release — the modal closes. The backdrop `click` handler fired because the browser dispatches the click to the common ancestor (the backdrop) when mousedown/mouseup land on different elements. Extremely annoying when selecting text in any input.

Fix: remember the `mousedown` target and close the modal only when both the press and the release happened on the backdrop itself. Lives in `base.html`, so it fixes every modal in the panel at once.

## Testing

`py_compile` / Jinja parse clean. Verified in a browser: no tile flash on page load; drag-selecting from an input past the modal border no longer closes it, while a plain backdrop click still does.