### PR TITLE
feat(install): used-port awareness when installing protocols

### DIFF
--- a/app.py
+++ b/app.py
@@ -2590,6 +2590,60 @@ async def api_check_server(request: Request, server_id: int):
         return JSONResponse({'error': str(e), 'connection': 'failed'}, status_code=500)
 
 
+def get_used_ports(ssh):
+    """Return {'udp': {port: proc}, 'tcp': {port: proc}} for listening sockets.
+
+    Used to suggest a free port before protocol installation and to validate
+    the chosen port, instead of letting 'docker run' fail with a half-created
+    container on 'port is already allocated'.
+    """
+    out, _, code = ssh.run_sudo_command("ss -H -l -n -p -u; echo ---TCP---; ss -H -l -n -p -t")
+    used = {'udp': {}, 'tcp': {}}
+    if code != 0 or not out:
+        return used
+    section = 'udp'
+    for line in out.split('\n'):
+        line = line.strip()
+        if line == '---TCP---':
+            section = 'tcp'
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        local = parts[3]
+        port = local.rsplit(':', 1)[-1]
+        if not port.isdigit():
+            continue
+        m = re.search(r'users:\(\("([^"]+)"', line)
+        used[section][port] = m.group(1) if m else '?'
+    return used
+
+
+# Protocols whose install port must be validated against used ports,
+# mapped to their transport. dns/adguard are skipped (internal bindings).
+INSTALL_PORT_TRANSPORT = {
+    'awg': 'udp', 'awg2': 'udp', 'awg3': 'udp', 'awg_legacy': 'udp',
+    'wireguard': 'udp',
+    'xray': 'tcp', 'telemt': 'tcp', 'socks5': 'tcp', 'nginx': 'tcp',
+}
+
+
+@app.get('/api/servers/{server_id}/used-ports', tags=["Servers"])
+async def api_used_ports(request: Request, server_id: int):
+    if not _check_admin(request):
+        return JSONResponse({'error': 'Forbidden'}, status_code=403)
+    try:
+        data = load_data()
+        if server_id >= len(data['servers']):
+            return JSONResponse({'error': 'Server not found'}, status_code=404)
+        ssh = get_ssh(data['servers'][server_id])
+        ssh.connect()
+        return get_used_ports(ssh)
+    except Exception as e:
+        logger.exception("Error getting used ports")
+        return JSONResponse({'error': str(e)}, status_code=500)
+
+
 @app.post('/api/servers/{server_id}/install', tags=["Protocols"])
 async def api_install_protocol(request: Request, server_id: int, req: InstallProtocolRequest):
     if not _check_admin(request):
@@ -2615,6 +2669,19 @@ async def api_install_protocol(request: Request, server_id: int, req: InstallPro
 
         ssh = get_ssh(server)
         ssh.connect()
+
+        # Validate the requested port before touching Docker: a busy port
+        # otherwise fails mid-install with a half-created broken container.
+        transport = INSTALL_PORT_TRANSPORT.get(install_base)
+        if transport and req.port and str(req.port).isdigit():
+            used = get_used_ports(ssh)
+            owner = used.get(transport, {}).get(str(req.port))
+            if owner:
+                return JSONResponse(
+                    {'error': f'Port {req.port}/{transport} is already used by {owner}. '
+                              f'Choose another port.'},
+                    status_code=400)
+
         docker_install_log = ensure_docker_installed(ssh)
         manager = get_protocol_manager(ssh, install_protocol)
 

--- a/templates/server.html
+++ b/templates/server.html
@@ -1018,6 +1018,63 @@
         return String(port);
     }
 
+    // ---- Used-port awareness for the install modal ----
+    // Fetches real listening ports from the server (not just same-family
+    // protocol records) so the suggested port is actually free.
+    const UDP_INSTALL_PROTOS = new Set(['awg', 'awg2', 'awg3', 'awg_legacy', 'wireguard']);
+    const SKIP_PORT_CHECK = new Set(['dns', 'adguard']); // internal bindings
+    window.usedPorts = { ts: 0, udp: {}, tcp: {} };
+
+    async function refreshUsedPorts(force) {
+        if (!force && Date.now() - window.usedPorts.ts < 15000) return;
+        try {
+            const r = await fetch(`/api/servers/${SERVER_ID}/used-ports`);
+            if (r.ok) {
+                const d = await r.json();
+                window.usedPorts.udp = d.udp || {};
+                window.usedPorts.tcp = d.tcp || {};
+                window.usedPorts.ts = Date.now();
+            }
+        } catch (e) { /* keep stale data */ }
+    }
+
+    function installPortTransport(proto) {
+        return UDP_INSTALL_PROTOS.has(protoBase(proto)) ? 'udp' : 'tcp';
+    }
+
+    function portTakenBy(port, proto) {
+        const p = parseInt(port, 10);
+        if (Number.isNaN(p)) return null;
+        const table = window.usedPorts[installPortTransport(proto)] || {};
+        return table[String(p)] || null;
+    }
+
+    function firstFreePort(from, proto) {
+        let p = parseInt(from, 10) || 55424;
+        let guard = 0;
+        while (portTakenBy(p, proto) && guard++ < 1000) p += 1;
+        return String(p);
+    }
+
+    function validateInstallPort() {
+        const portInput = document.getElementById('installPort');
+        const portHint = document.getElementById('installPortHint');
+        const btn = document.getElementById('installBtn');
+        if (portInput.disabled || SKIP_PORT_CHECK.has(protoBase(currentInstallProto))) return;
+        const owner = portTakenBy(portInput.value, currentInstallProto);
+        if (owner) {
+            portInput.style.borderColor = '#ef4444';
+            portHint.style.color = '#ef4444';
+            portHint.textContent = _('port_in_use_by').replace('{port}', portInput.value).replace('{owner}', owner);
+            btn.disabled = true;
+        } else {
+            portInput.style.borderColor = '';
+            portHint.style.color = '';
+            if (portHint.dataset.orig) portHint.textContent = portHint.dataset.orig;
+            btn.disabled = false;
+        }
+    }
+
     function orderedProtocolEntries(protocols) {
         const entries = Object.entries(protocols || {});
         const order = new Map(MARKETPLACE_APPS.map((app, idx) => [app.proto, idx]));
@@ -1790,6 +1847,19 @@
         document.getElementById('installForm').classList.remove('hidden');
         document.getElementById('installProgress').classList.add('hidden');
         document.getElementById('installDone').style.display = 'none';
+
+        // Live port validation + auto-suggest a truly free port
+        portHint.dataset.orig = portHint.textContent;
+        portInput.oninput = validateInstallPort;
+        validateInstallPort();
+        refreshUsedPorts().then(() => {
+            if (!portInput.disabled && !SKIP_PORT_CHECK.has(protoBase(currentInstallProto))
+                    && portTakenBy(portInput.value, currentInstallProto)) {
+                portInput.value = firstFreePort(portInput.value, currentInstallProto);
+            }
+            validateInstallPort();
+        });
+
         openModal('installModal');
     }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Reset traffic",
   "resetting": "Resetting...",
   "reset_traffic_confirm": "Reset this user's current traffic? Total statistics will be kept.",
-  "traffic_reset_success": "Traffic reset"
+  "traffic_reset_success": "Traffic reset",
+  "port_in_use_by": "Port {port} is already used by {owner}. Choose another port."
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -403,5 +403,6 @@
   "reset_traffic": "بازنشانی ترافیک",
   "resetting": "در حال بازنشانی...",
   "reset_traffic_confirm": "ترافیک فعلی این کاربر بازنشانی شود؟ آمار کل حفظ میشود.",
-  "traffic_reset_success": "ترافیک بازنشانی شد"
+  "traffic_reset_success": "ترافیک بازنشانی شد",
+  "port_in_use_by": "پورت {port} قبلاً توسط {owner} استفاده شده است. پورت دیگری انتخاب کنید."
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -403,5 +403,6 @@
   "reset_traffic": "Réinitialiser le trafic",
   "resetting": "Réinitialisation...",
   "reset_traffic_confirm": "Réinitialiser le trafic actuel de cet utilisateur ? Les statistiques totales seront conservées.",
-  "traffic_reset_success": "Trafic réinitialisé"
+  "traffic_reset_success": "Trafic réinitialisé",
+  "port_in_use_by": "Le port {port} est déjà utilisé par {owner}. Choisissez un autre port."
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -436,5 +436,6 @@
   "reset_traffic": "Сбросить трафик",
   "resetting": "Сброс...",
   "reset_traffic_confirm": "Сбросить текущий трафик пользователя? Общая статистика сохранится.",
-  "traffic_reset_success": "Трафик сброшен"
+  "traffic_reset_success": "Трафик сброшен",
+  "port_in_use_by": "Порт {port} уже занят ({owner}). Выберите другой порт."
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -403,5 +403,6 @@
   "reset_traffic": "重置流量",
   "resetting": "正在重置...",
   "reset_traffic_confirm": "重置此用户的当前流量？总统计将保留。",
-  "traffic_reset_success": "流量已重置"
+  "traffic_reset_success": "流量已重置",
+  "port_in_use_by": "端口 {port} 已被 {owner} 占用，请选择其他端口。"
 }


### PR DESCRIPTION
## Problem

The install modal defaults to a fixed port and only avoids ports of same-family instances. Installing e.g. AWG3 on a host where AWG2 already holds 55424 fails **mid-install** with a half-created broken container (`port is already allocated`) — the user finds out after the image build, and has to clean up manually.

## Changes

- **`GET /api/servers/{id}/used-ports`** — returns real listening UDP/TCP ports on the server (via `ss`), each with the owning process name
- **`api_install_protocol`** — rejects a busy port **upfront** with a clear error naming the owning process, before any `docker run`
- **Install modal** — fetches used ports on open, auto-suggests the first free port, and live-validates manual input (red field + hint + disabled Install button)
- New translation key `port_in_use_by` (en/ru/fr/fa/zh)

## Compatibility

Read-only endpoint, no changes to existing installs. Servers where the port is free behave exactly as before.

## Testing

`py_compile` + Jinja parse clean. Verified live: with AWG2 holding the default port, the AWG3 install modal immediately suggested the next free port; manually entering the busy port blocked the Install button with «Port 55424 is already used by amnezia-awg2»; installation on the suggested port succeeded.