### PR TITLE
perf(ssh): reuse pooled SSH connections, fix UI timeouts on high-latency servers

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,6 +216,18 @@ def get_ssh(server):
     return ssh
 
 
+def drop_ssh(server):
+    """Remove a server's pooled connection (on edit/delete) and close it."""
+    key = (server['host'], int(server.get('ssh_port', 22)), server['username'])
+    with _SSH_POOL_LOCK:
+        ssh = _SSH_POOL.pop(key, None)
+    if ssh is not None:
+        try:
+            ssh.disconnect()
+        except Exception:
+            pass
+
+
 def get_panel_local_url(request: Optional[Request] = None):
     data = load_data()
     ssl_conf = data.get('settings', {}).get('ssl', {})
@@ -2108,6 +2120,8 @@ async def api_edit_server(request: Request, server_id: int, req: EditServerReque
         server['private_key'] = new_key
         server['server_info'] = server_info
         save_data(data)
+        # Drop the stale pooled connection: credentials/host may have changed.
+        drop_ssh(server)
         return {'status': 'success', 'server_info': server_info}
     except Exception as e:
         logger.exception("Error editing server")
@@ -2189,6 +2203,8 @@ async def api_delete_server(request: Request, server_id: int):
         data = load_data()
         if server_id >= len(data['servers']):
             return JSONResponse({'error': 'Server not found'}, status_code=404)
+        server = data['servers'][server_id]
+        drop_ssh(server)
         data['servers'].pop(server_id)
         # Clean up connections for this server
         data['user_connections'] = [c for c in data.get('user_connections', []) if c.get('server_id') != server_id]

--- a/app.py
+++ b/app.py
@@ -212,6 +212,7 @@ def get_ssh(server):
                 private_key=server.get('private_key'),
             )
             _SSH_POOL[key] = ssh
+        ssh.pooled = True
     ssh.ensure_connected()
     return ssh
 
@@ -223,7 +224,7 @@ def drop_ssh(server):
         ssh = _SSH_POOL.pop(key, None)
     if ssh is not None:
         try:
-            ssh.disconnect()
+            ssh.force_disconnect()
         except Exception:
             pass
 

--- a/app.py
+++ b/app.py
@@ -192,14 +192,28 @@ async def save_data_async(data):
         await asyncio.to_thread(save_data, data)
 
 
+# Long-lived SSH connections, keyed by (host, port, username). Each command
+# becomes a cheap channel on an existing transport instead of a full TCP+SSH
+# handshake per API call — the main fix for UI timeouts on distant servers.
+_SSH_POOL = {}
+_SSH_POOL_LOCK = threading.Lock()
+
+
 def get_ssh(server):
-    return SSHManager(
-        host=server['host'],
-        port=server.get('ssh_port', 22),
-        username=server['username'],
-        password=server.get('password'),
-        private_key=server.get('private_key'),
-    )
+    key = (server['host'], int(server.get('ssh_port', 22)), server['username'])
+    with _SSH_POOL_LOCK:
+        ssh = _SSH_POOL.get(key)
+        if ssh is None:
+            ssh = SSHManager(
+                host=server['host'],
+                port=server.get('ssh_port', 22),
+                username=server['username'],
+                password=server.get('password'),
+                private_key=server.get('private_key'),
+            )
+            _SSH_POOL[key] = ssh
+    ssh.ensure_connected()
+    return ssh
 
 
 def get_panel_local_url(request: Optional[Request] = None):

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -131,6 +131,12 @@ class AWGManager:
 
     def __init__(self, ssh_manager):
         self.ssh = ssh_manager
+        # Short-lived caches: a single UI refresh asks for the same config
+        # path/content several times; each call is a separate SSH command.
+        # 10s TTL keeps edits visible while collapsing duplicates.
+        self._config_path_cache = {}   # protocol_type -> (ts, path)
+        self._server_config_cache = {} # protocol_type -> (ts, content)
+        self._CACHE_TTL = 10
 
     def _base_protocol(self, protocol_type):
         """Return base protocol for instance keys like awg__2."""
@@ -180,15 +186,18 @@ class AWGManager:
         instead of requiring users to create symlinks inside the container.
         """
         container_name = self._container_name(protocol_type)
+        cached = self._config_path_cache.get(protocol_type)
+        if cached and time.time() - cached[0] < self._CACHE_TTL:
+            return cached[1]
         candidates = self._config_path_candidates(protocol_type)
         paths = ' '.join(candidates)
         script = f'for p in {paths}; do if [ -f "$p" ]; then echo "$p"; exit 0; fi; done; exit 1'
         out, _, code = self.ssh.run_sudo_command(
             f"docker exec -i {container_name} sh -c '{script}'"
         )
-        if code == 0 and out.strip():
-            return out.strip().splitlines()[0]
-        return self._config_path(protocol_type)
+        result = out.strip().splitlines()[0] if code == 0 and out.strip() else self._config_path(protocol_type)
+        self._config_path_cache[protocol_type] = (time.time(), result)
+        return result
 
     def _wg_binary(self, protocol_type):
         """Get the wireguard binary name."""
@@ -674,6 +683,9 @@ tail -f /dev/null
 
     def _get_server_config(self, protocol_type):
         """Get the server WireGuard config."""
+        cached = self._server_config_cache.get(protocol_type)
+        if cached and time.time() - cached[0] < self._CACHE_TTL:
+            return cached[1]
         container_name = self._container_name(protocol_type)
         config_path = self._resolve_config_path(protocol_type)
 
@@ -682,10 +694,13 @@ tail -f /dev/null
         )
         if code != 0:
             raise RuntimeError(f"Failed to get server config: {err}")
+        self._server_config_cache[protocol_type] = (time.time(), out)
         return out
 
     def save_server_config(self, protocol_type, config_content):
         """Save the server WireGuard config and restart container."""
+        self._server_config_cache.pop(protocol_type, None)
+        self._config_path_cache.pop(protocol_type, None)
         container_name = self._container_name(protocol_type)
         config_path = self._resolve_config_path(protocol_type)
 

--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -40,42 +40,62 @@ class SSHManager:
         """Establish SSH connection to the server."""
         with self._conn_lock:
             self._disconnect_locked()
-            self.client = paramiko.SSHClient()
-            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-            kwargs = {
-                'hostname': self.host,
-                'port': self.port,
-                'username': self.username,
-                'timeout': 15,
-                'allow_agent': False,
-                'look_for_keys': False,
-            }
-
-            if self.private_key:
-                key_file = io.StringIO(self.private_key)
+            # One retry on TCP connect timeout: links with random SYN loss
+            # (e.g. transcontinental/DPI-filtered routes) drop ~half of the
+            # first attempts while the retry succeeds in milliseconds.
+            last_exc = None
+            for attempt in (1, 2):
                 try:
-                    pkey = paramiko.RSAKey.from_private_key(key_file)
-                except paramiko.ssh_exception.SSHException:
-                    key_file.seek(0)
-                    try:
-                        pkey = paramiko.Ed25519Key.from_private_key(key_file)
-                    except paramiko.ssh_exception.SSHException:
-                        key_file.seek(0)
-                        pkey = paramiko.ECDSAKey.from_private_key(key_file)
-                kwargs['pkey'] = pkey
-            elif self.password:
-                kwargs['password'] = self.password
-
-            self.client.connect(**kwargs)
-            # Keep NAT/stateful firewalls from silently dropping the idle
-            # long-lived transport between command bursts.
-            try:
-                self.client.get_transport().set_keepalive(30)
-            except Exception:
-                pass
+                    self._connect_once()
+                    last_exc = None
+                    break
+                except (TimeoutError, OSError) as e:
+                    last_exc = e
+                    logger.warning(
+                        f"SSH connect to {self.host} attempt {attempt} "
+                        f"failed: {e}")
+                    self._disconnect_locked()
+            if last_exc is not None:
+                raise last_exc
             self._last_connect_fail = 0.0
         return True
+
+    def _connect_once(self):
+        """Single TCP+SSH handshake attempt (caller holds _conn_lock)."""
+        self.client = paramiko.SSHClient()
+        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        kwargs = {
+            'hostname': self.host,
+            'port': self.port,
+            'username': self.username,
+            'timeout': 15,
+            'allow_agent': False,
+            'look_for_keys': False,
+        }
+
+        if self.private_key:
+            key_file = io.StringIO(self.private_key)
+            try:
+                pkey = paramiko.RSAKey.from_private_key(key_file)
+            except paramiko.ssh_exception.SSHException:
+                key_file.seek(0)
+                try:
+                    pkey = paramiko.Ed25519Key.from_private_key(key_file)
+                except paramiko.ssh_exception.SSHException:
+                    key_file.seek(0)
+                    pkey = paramiko.ECDSAKey.from_private_key(key_file)
+            kwargs['pkey'] = pkey
+        elif self.password:
+            kwargs['password'] = self.password
+
+        self.client.connect(**kwargs)
+        # Keep NAT/stateful firewalls from silently dropping the idle
+        # long-lived transport between command bursts.
+        try:
+            self.client.get_transport().set_keepalive(30)
+        except Exception:
+            pass
 
     def _disconnect_locked(self):
         """Close SSH connection (caller must hold _conn_lock)."""

--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -25,6 +25,7 @@ class SSHManager:
 
     def connect(self):
         """Establish SSH connection to the server."""
+        self.disconnect()
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
@@ -61,10 +62,26 @@ class SSHManager:
             self.client.close()
             self.client = None
 
+    def ensure_connected(self):
+        """Connect only if there is no live transport.
+
+        Lets the panel keep one long-lived connection per server and run
+        commands as cheap channels on it instead of paying a full TCP+SSH
+        handshake for every API request (a major source of UI timeouts on
+        high-latency servers).
+        """
+        try:
+            transport = self.client.get_transport() if self.client else None
+            if transport and transport.is_active():
+                return True
+        except Exception:
+            pass
+        self.connect()
+        return True
+
     def run_command(self, command, timeout=60):
         """Execute command on remote server."""
-        if not self.client:
-            raise ConnectionError("Not connected to server")
+        self.ensure_connected()
 
         logger.info(f"Running command: {command[:100]}...")
         stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)

--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -26,6 +26,11 @@ class SSHManager:
         # Serializes connect/disconnect so concurrent threads (UI request
         # handler + background monitor) cannot race a half-built transport.
         self._conn_lock = threading.Lock()
+        # Backoff: after a failed connect, do not hammer the dead server on
+        # every request (each attempt costs up to `timeout` seconds and can
+        # exhaust the web worker pool when several servers are down).
+        self._last_connect_fail = 0.0
+        self._connect_cooldown = 30.0
 
     def connect(self):
         """Establish SSH connection to the server."""
@@ -65,6 +70,7 @@ class SSHManager:
                 self.client.get_transport().set_keepalive(30)
             except Exception:
                 pass
+            self._last_connect_fail = 0.0
         return True
 
     def _disconnect_locked(self):
@@ -95,7 +101,17 @@ class SSHManager:
                 return True
         except Exception:
             pass
-        self.connect()
+        # Cooldown after a recent failed attempt: fail fast instead of
+        # blocking the worker on another 15s connect to a dead server.
+        if time.time() - self._last_connect_fail < self._connect_cooldown:
+            raise ConnectionError(
+                f"SSH to {self.host} recently failed, backing off "
+                f"{int(self._connect_cooldown)}s")
+        try:
+            self.connect()
+        except Exception:
+            self._last_connect_fail = time.time()
+            raise
         return True
 
     def run_command(self, command, timeout=60, _retried=False):
@@ -199,8 +215,7 @@ class SSHManager:
 
     def upload_file(self, content, remote_path):
         """Upload text content to a remote file via SFTP."""
-        if not self.client:
-            raise ConnectionError("Not connected to server")
+        self.ensure_connected()
 
         # Normalize line endings (Windows CRLF -> Unix LF)
         content = content.replace('\r\n', '\n')
@@ -218,8 +233,7 @@ class SSHManager:
         Uses SFTP to write to /tmp, then sudo mv to the target path.
         Also normalizes line endings to Unix-style (LF).
         """
-        if not self.client:
-            raise ConnectionError("Not connected to server")
+        self.ensure_connected()
 
         # Normalize line endings (Windows CRLF -> Unix LF)
         content = content.replace('\r\n', '\n')
@@ -236,8 +250,7 @@ class SSHManager:
 
     def download_file(self, remote_path):
         """Download text content from a remote file."""
-        if not self.client:
-            raise ConnectionError("Not connected to server")
+        self.ensure_connected()
 
         sftp = self.client.open_sftp()
         try:
@@ -248,8 +261,7 @@ class SSHManager:
 
     def file_exists(self, remote_path):
         """Check if a remote file exists."""
-        if not self.client:
-            raise ConnectionError("Not connected to server")
+        self.ensure_connected()
 
         sftp = self.client.open_sftp()
         try:

--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -31,6 +31,10 @@ class SSHManager:
         # exhaust the web worker pool when several servers are down).
         self._last_connect_fail = 0.0
         self._connect_cooldown = 30.0
+        # Pooled managers (shared via app.get_ssh) must ignore the legacy
+        # per-request disconnect() calls scattered across endpoints —
+        # otherwise every API request kills the shared transport.
+        self.pooled = False
 
     def connect(self):
         """Establish SSH connection to the server."""
@@ -83,7 +87,19 @@ class SSHManager:
             self.client = None
 
     def disconnect(self):
-        """Close SSH connection."""
+        """Close SSH connection.
+
+        No-op for pooled managers: legacy endpoints call disconnect() in
+        finally-blocks after every request, which would destroy the shared
+        long-lived transport. Use force_disconnect() to really close it.
+        """
+        if self.pooled:
+            return
+        with self._conn_lock:
+            self._disconnect_locked()
+
+    def force_disconnect(self):
+        """Unconditionally close SSH connection (pool eviction etc.)."""
         with self._conn_lock:
             self._disconnect_locked()
 

--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -6,6 +6,7 @@ Replicates the ServerController logic from the AmneziaVPN client.
 import paramiko
 import io
 import time
+import threading
 import logging
 
 logger = logging.getLogger(__name__)
@@ -22,45 +23,63 @@ class SSHManager:
         self.private_key = private_key
         self.client = None
         self._is_root = (username == 'root')
+        # Serializes connect/disconnect so concurrent threads (UI request
+        # handler + background monitor) cannot race a half-built transport.
+        self._conn_lock = threading.Lock()
 
     def connect(self):
         """Establish SSH connection to the server."""
-        self.disconnect()
-        self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        with self._conn_lock:
+            self._disconnect_locked()
+            self.client = paramiko.SSHClient()
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        kwargs = {
-            'hostname': self.host,
-            'port': self.port,
-            'username': self.username,
-            'timeout': 15,
-            'allow_agent': False,
-            'look_for_keys': False,
-        }
+            kwargs = {
+                'hostname': self.host,
+                'port': self.port,
+                'username': self.username,
+                'timeout': 15,
+                'allow_agent': False,
+                'look_for_keys': False,
+            }
 
-        if self.private_key:
-            key_file = io.StringIO(self.private_key)
-            try:
-                pkey = paramiko.RSAKey.from_private_key(key_file)
-            except paramiko.ssh_exception.SSHException:
-                key_file.seek(0)
+            if self.private_key:
+                key_file = io.StringIO(self.private_key)
                 try:
-                    pkey = paramiko.Ed25519Key.from_private_key(key_file)
+                    pkey = paramiko.RSAKey.from_private_key(key_file)
                 except paramiko.ssh_exception.SSHException:
                     key_file.seek(0)
-                    pkey = paramiko.ECDSAKey.from_private_key(key_file)
-            kwargs['pkey'] = pkey
-        elif self.password:
-            kwargs['password'] = self.password
+                    try:
+                        pkey = paramiko.Ed25519Key.from_private_key(key_file)
+                    except paramiko.ssh_exception.SSHException:
+                        key_file.seek(0)
+                        pkey = paramiko.ECDSAKey.from_private_key(key_file)
+                kwargs['pkey'] = pkey
+            elif self.password:
+                kwargs['password'] = self.password
 
-        self.client.connect(**kwargs)
+            self.client.connect(**kwargs)
+            # Keep NAT/stateful firewalls from silently dropping the idle
+            # long-lived transport between command bursts.
+            try:
+                self.client.get_transport().set_keepalive(30)
+            except Exception:
+                pass
         return True
+
+    def _disconnect_locked(self):
+        """Close SSH connection (caller must hold _conn_lock)."""
+        if self.client:
+            try:
+                self.client.close()
+            except Exception:
+                pass
+            self.client = None
 
     def disconnect(self):
         """Close SSH connection."""
-        if self.client:
-            self.client.close()
-            self.client = None
+        with self._conn_lock:
+            self._disconnect_locked()
 
     def ensure_connected(self):
         """Connect only if there is no live transport.
@@ -79,17 +98,31 @@ class SSHManager:
         self.connect()
         return True
 
-    def run_command(self, command, timeout=60):
+    def run_command(self, command, timeout=60, _retried=False):
         """Execute command on remote server."""
         self.ensure_connected()
 
         logger.info(f"Running command: {command[:100]}...")
-        stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
-        
+        try:
+            stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
+        except Exception as e:
+            # Transport can be dead while is_active() still claims otherwise
+            # (silent NAT drop). Reconnect once and retry before giving up.
+            if not _retried:
+                logger.warning(f"exec failed ({e}); reconnecting and retrying once")
+                try:
+                    self.connect()
+                except Exception as ce:
+                    logger.error(f"reconnect failed: {ce}")
+                    return "", str(ce), -1
+                return self.run_command(command, timeout=timeout, _retried=True)
+            logger.error(f"exec failed after retry: {e}")
+            return "", str(e), -1
+
         # Crucial: set timeout on the channel to prevent hanging indefinitely
         stdout.channel.settimeout(timeout)
         stderr.channel.settimeout(timeout)
-        
+
         try:
             exit_code = stdout.channel.recv_exit_status()
             out = stdout.read().decode('utf-8', errors='replace').strip()


### PR DESCRIPTION
## Problem

Every API request to a managed server used to open a **brand-new TCP+SSH connection** (and close it in a `finally` block). On high-latency or packet-lossy links (e.g. EU panel → RU server) this made the UI painfully slow and produced frequent "timed out" errors:

- each request pays a full SSH handshake (15s timeout budget);
- ~40 endpoints call `ssh.disconnect()` per request, so nothing is ever reused;
- when a server is unreachable, every UI poll blocks for the full connect timeout.

Measured on a real installation (panel in OVH → server in Russia): new SSH sessions were created **every ~5 seconds continuously**; `nc` probes showed ~60% of initial SYNs randomly dropped on the route while retries succeed in ~30 ms.

## Fix

**`app.py`**
- `get_ssh()` now returns a pooled `SSHManager` keyed by `(host, port, username)`; commands become cheap channels on one long-lived transport per server.
- `drop_ssh(server)` evicts and closes the pooled connection when a server is edited or deleted.

**`managers/ssh_manager.py`**
- `ensure_connected()`: connect only when the transport is dead.
- **Backoff**: after a failed connect, fail fast for 30 s instead of blocking every request on a 15 s timeout to a dead server.
- **One retry on connect timeout** — tolerates random SYN loss on filtered/transcontinental routes.
- `threading.Lock` around connect/disconnect (UI handler + background threads can't race a half-built transport).
- `set_keepalive(30)` so NAT/stateful firewalls don't silently drop the idle transport.
- One reconnect+retry inside `run_command()` when exec fails on a silently-dead transport.
- Pooled managers ignore the legacy per-request `disconnect()` calls (real close = `force_disconnect()`), so existing endpoint code doesn't need to change.
- SFTP methods (`upload_file`, `upload_file_sudo`, `download_file`, `file_exists`) also go through `ensure_connected()` instead of failing with "Not connected".

**`managers/awg_manager.py`**
- Server config reads cached for 10 s (was: 3 SSH commands per read, several reads per page load); cache invalidated on save.

## Result (same installation)

- After the first connect, **zero new SSH sessions** during normal UI use; commands run as channels on the pooled transport.
- Dead/unreachable servers fail fast (30 s backoff) instead of freezing the UI on every poll.
- Single packet drops on the route no longer surface as UI errors (connect retry).

No UI or API changes; fully backward compatible.