### PR TITLE
fix: stuck "loading connections.."  on /my page

### DIFF
--- a/templates/my_connections.html
+++ b/templates/my_connections.html
@@ -509,5 +509,10 @@
             }, QR_FRAME_MS);
         }
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadSelfServiceOptions();
+        loadConnections();
+    });
 </script>
 {% endblock %}

--- a/tests/test_my_connections_page.py
+++ b/tests/test_my_connections_page.py
@@ -1,0 +1,26 @@
+import re
+import unittest
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parents[1] / 'templates' / 'my_connections.html'
+
+
+class TestMyConnectionsPageInit(unittest.TestCase):
+    def test_page_loads_connections_on_dom_ready(self):
+        source = TEMPLATE.read_text(encoding='utf-8')
+        match = re.search(
+            r"document\.addEventListener\(\s*['\"]DOMContentLoaded['\"]\s*,\s*\(\)\s*=>\s*\{(.*?)\}\s*\)",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            match,
+            'DOMContentLoaded initializer is missing from my_connections.html',
+        )
+        body = match.group(1)
+        self.assertIn('loadSelfServiceOptions()', body)
+        self.assertIn('loadConnections()', body)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Regular users never saw their connections on `/my`: the page stayed on "Loading connections..." and the Create button never appeared.
- Root cause: after the list was moved to a JS fetch, merge `2dbaf78` dropped the `DOMContentLoaded` handler that called `loadConnections()` and `loadSelfServiceOptions()`. The loading spinner is the default DOM state, and those functions only ran after create/delete — never on first visit.
- Restores the page-load initializer in `templates/my_connections.html` and adds `tests/test_my_connections_page.py` so a future merge cannot drop it silently.