### PR TITLE
feat: add flexible self-service protocols

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,8 @@ from connection_service import (
     DEFAULT_SELF_SERVICE_SETTINGS,
     RateLimitError,
     SelfServiceError,
+    sanitize_allowed_protocols,
+    self_service_protocol_choices,
 )
 
 # Configure logging
@@ -4476,6 +4478,7 @@ async def api_my_connections(request: Request):
             c['server_name'] = data['servers'][sid].get('name', '')
         else:
             c['server_name'] = 'Unknown'
+        c['protocol_name'] = protocol_display_name(c.get('protocol', ''))
     return {'connections': conns}
 
 
@@ -4658,7 +4661,14 @@ async def settings_page(request: Request):
     if not user:
         return RedirectResponse('/login')
     data = load_data()
-    return tpl(request, 'settings.html', settings=data.get('settings', {}), servers=data.get('servers', []), current_version=CURRENT_VERSION)
+    return tpl(
+        request,
+        'settings.html',
+        settings=data.get('settings', {}),
+        servers=data.get('servers', []),
+        current_version=CURRENT_VERSION,
+        self_service_protocol_choices=self_service_protocol_choices(),
+    )
 
 
 @app.get('/api/settings', tags=["Settings"])
@@ -4800,7 +4810,7 @@ async def save_settings(request: Request, payload: SaveSettingsRequest):
         'last_error': old_auto_backup.get('last_error')
     }
     self_service = payload.self_service.dict()
-    self_service['allowed_protocols'] = [p for p in self_service.get('allowed_protocols', []) if p in ('awg', 'awg2')]
+    self_service['allowed_protocols'] = sanitize_allowed_protocols(self_service.get('allowed_protocols'))
     settings['self_service'] = self_service
     save_data(data)
     logger.info("Settings saved (including captcha, telegram and auto backup)")

--- a/connection_service.py
+++ b/connection_service.py
@@ -10,6 +10,72 @@ DISALLOWED_CONNECTION_NAME_CHARS = set('<>"\'&')
 
 logger = logging.getLogger(__name__)
 
+SELF_SERVICE_PROTOCOL_ORDER = (
+    'awg', 'awg2', 'awg3', 'awg_legacy', 'xray', 'telemt', 'wireguard',
+)
+
+SELF_SERVICE_PROTOCOLS = frozenset(SELF_SERVICE_PROTOCOL_ORDER)
+
+_PROTOCOL_DISPLAY_NAMES = {
+    'awg': 'AmneziaWG',
+    'awg2': 'AmneziaWG 2.0',
+    'awg3': 'AmneziaWG 3.1',
+    'awg_legacy': 'AmneziaWG Legacy',
+    'xray': 'Xray',
+    'telemt': 'Telemt',
+    'wireguard': 'WireGuard',
+}
+
+
+def protocol_base(protocol: str) -> str:
+    return str(protocol or 'awg').split('__', 1)[0]
+
+
+def protocol_instance(protocol: str) -> int:
+    parts = str(protocol or '').split('__', 1)
+    if len(parts) == 2:
+        try:
+            return max(1, int(parts[1]))
+        except ValueError:
+            return 1
+    return 1
+
+
+def sanitize_allowed_protocols(allowed) -> list:
+    seen = set()
+    result = []
+    for proto in allowed or []:
+        base = protocol_base(proto)
+        if base in SELF_SERVICE_PROTOCOLS and base not in seen:
+            seen.add(base)
+            result.append(base)
+    return result
+
+
+def self_service_protocol_display_name(protocol: str) -> str:
+    base = protocol_base(protocol)
+    idx = protocol_instance(protocol)
+    name = _PROTOCOL_DISPLAY_NAMES.get(base, base)
+    return name if idx <= 1 else f'{name} #{idx}'
+
+
+def self_service_protocol_choices():
+    return [
+        {'id': proto, 'name': self_service_protocol_display_name(proto)}
+        for proto in SELF_SERVICE_PROTOCOL_ORDER
+    ]
+
+
+def server_self_service_protocols(server, allowed_bases) -> list:
+    allowed = set(sanitize_allowed_protocols(allowed_bases))
+    if not allowed:
+        return []
+    return [
+        proto
+        for proto in (server.get('protocols') or {}).keys()
+        if protocol_base(proto) in allowed
+    ]
+
 
 DEFAULT_SELF_SERVICE_SETTINGS = {
     'enabled': False,
@@ -64,15 +130,15 @@ class ConnectionService:
         user_connections = self._user_connections(data, user['id'])
         max_connections = int(settings.get('max_connections_per_user', 5))
         remaining = max(0, max_connections - len(user_connections))
-        allowed_protocols = set(settings.get('allowed_protocols') or []) & {'awg', 'awg2'}
+        allowed_bases = sanitize_allowed_protocols(settings.get('allowed_protocols'))
         servers = []
         for server_id, server in enumerate(data.get('servers', [])):
             if not server.get('self_service_enabled', False):
                 continue
-            protocols = []
-            for protocol in ('awg', 'awg2'):
-                if protocol in allowed_protocols and protocol in server.get('protocols', {}):
-                    protocols.append({'protocol': protocol, 'name': self._protocol_name(protocol)})
+            protocols = [
+                {'protocol': protocol, 'name': self_service_protocol_display_name(protocol)}
+                for protocol in server_self_service_protocols(server, allowed_bases)
+            ]
             if protocols:
                 servers.append({
                     'id': server_id,
@@ -253,8 +319,8 @@ class ConnectionService:
         server = data['servers'][server_id]
         if not server.get('self_service_enabled', False):
             raise SelfServiceError('Server self-service is disabled', status_code=403, forbidden=True)
-        allowed = set(settings.get('allowed_protocols') or []) & {'awg', 'awg2'}
-        if protocol not in allowed:
+        allowed_bases = set(sanitize_allowed_protocols(settings.get('allowed_protocols')))
+        if protocol_base(protocol) not in allowed_bases:
             raise SelfServiceError('Protocol is not allowed')
         if protocol not in server.get('protocols', {}):
             raise SelfServiceError('Protocol is not installed on this server')
@@ -272,8 +338,8 @@ class ConnectionService:
         return clean
 
     def _validate_protocol(self, protocol):
-        if protocol not in ('awg', 'awg2'):
-            raise SelfServiceError('Only awg and awg2 are supported')
+        if protocol_base(protocol) not in SELF_SERVICE_PROTOCOLS:
+            raise SelfServiceError('Protocol is not supported for self-service')
 
     def _user_connections(self, data, user_id):
         return [c for c in data.get('user_connections', []) if c.get('user_id') == user_id]
@@ -307,5 +373,3 @@ class ConnectionService:
         except Exception as e:
             logger.warning("Rollback failed for client %s: %s", client_id, e)
 
-    def _protocol_name(self, protocol):
-        return 'AWG 2' if protocol == 'awg2' else 'AWG'

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -15,6 +15,15 @@ from typing import Optional, Callable
 
 import httpx
 
+from connection_service import (
+    SELF_SERVICE_PROTOCOLS,
+    protocol_base,
+    protocol_instance,
+    sanitize_allowed_protocols,
+    self_service_protocol_display_name,
+    server_self_service_protocols,
+)
+
 logger = logging.getLogger(__name__)
 
 # ----------------------------------------------------------------------- #
@@ -24,7 +33,12 @@ _bot_task: Optional[asyncio.Task] = None
 _callback_refs = {}
 _pending_inputs = {}
 
-CLIENT_PROTOCOLS = {"awg", "awg2", "awg_legacy", "xray", "telemt", "wireguard"}
+_EXTRA_PROTOCOL_DISPLAY_NAMES = {
+    "dns": "AmneziaDNS",
+    "socks5": "SOCKS5",
+    "adguard": "AdGuard Home",
+    "nginx": "NGINX",
+}
 SERVICE_PROTOCOLS = {"dns", "adguard", "socks5", "nginx"}
 
 TG_TRANSLATIONS = {
@@ -357,6 +371,8 @@ def _tg_lang(from_user: Optional[dict]) -> str:
 def _tt(lang: str, key: str, **kwargs) -> str:
     text = TG_TRANSLATIONS.get(lang, TG_TRANSLATIONS["en"]).get(key, TG_TRANSLATIONS["en"].get(key, key))
     return text.format(**kwargs) if kwargs else text
+
+
 def _format_bytes(value) -> str:
     try:
         value = float(value or 0)
@@ -372,31 +388,13 @@ def _format_bytes(value) -> str:
     return f"{value:.2f} {units[idx]}"
 
 
-def _proto_base(protocol: str) -> str:
-    return str(protocol or "awg").split("__", 1)[0]
-
-
 def _protocol_display_name(protocol: str) -> str:
-    base = _proto_base(protocol)
-    names = {
-        "awg": "AmneziaWG",
-        "awg2": "AmneziaWG 2.0",
-        "awg_legacy": "AmneziaWG Legacy",
-        "xray": "Xray",
-        "telemt": "Telemt",
-        "dns": "AmneziaDNS",
-        "wireguard": "WireGuard",
-        "socks5": "SOCKS5",
-        "adguard": "AdGuard Home",
-        "nginx": "NGINX",
-    }
-    name = names.get(base, base)
-    if "__" in str(protocol):
-        try:
-            return f"{name} #{int(str(protocol).split('__', 1)[1])}"
-        except Exception:
-            return name
-    return name
+    base = protocol_base(protocol)
+    if base in SELF_SERVICE_PROTOCOLS:
+        return self_service_protocol_display_name(protocol)
+    name = _EXTRA_PROTOCOL_DISPLAY_NAMES.get(base, base)
+    idx = protocol_instance(protocol)
+    return name if idx <= 1 else f"{name} #{idx}"
 
 
 def _find_user(load_data_fn: Callable, tg_id: str, username: Optional[str] = None):
@@ -448,37 +446,45 @@ def _resolve_ref(data_str: str):
 # ----------------------------------------------------------------------- #
 #  Self-service helpers
 # ----------------------------------------------------------------------- #
+def _self_service_settings(data: dict) -> dict:
+    return (data.get("settings") or {}).get("self_service") or {}
+
+
 def _self_service_is_enabled(data: dict) -> bool:
     """Returns True if self-service is enabled globally in panel settings."""
-    settings = data.get("settings", {}) or {}
-    ss = settings.get("self_service", {}) or {}
-    return bool(ss.get("enabled", False))
+    return bool(_self_service_settings(data).get("enabled", False))
 
 
 def _self_service_telegram_enabled(data: dict) -> bool:
     """Returns True if self-service is enabled and Telegram channel is active."""
-    if not _self_service_is_enabled(data):
-        return False
-    settings = data.get("settings", {}) or {}
-    ss = settings.get("self_service", {}) or {}
-    return bool(ss.get("telegram_enabled", False))
+    ss = _self_service_settings(data)
+    return bool(ss.get("enabled", False) and ss.get("telegram_enabled", False))
 
 
-def _get_eligible_servers(data: dict, allowed_protocols: Optional[set] = None) -> list:
+def _get_eligible_servers(data: dict, allowed_protocols=None) -> list:
     """Returns list of (server_id, server, available_protos) tuples for self-service."""
     if allowed_protocols is None:
-        settings = data.get("settings", {}) or {}
-        ss = settings.get("self_service", {}) or {}
-        allowed_protocols = set(ss.get("allowed_protocols", []) or []) & {"awg", "awg2"}
+        allowed_protocols = _self_service_settings(data).get("allowed_protocols", [])
+    allowed_bases = sanitize_allowed_protocols(allowed_protocols)
     servers = data.get("servers", [])
     eligible = []
     for sid, server in enumerate(servers):
         if not server.get("self_service_enabled", False):
             continue
-        available = [p for p in ("awg", "awg2") if p in allowed_protocols and p in server.get("protocols", {})]
+        available = server_self_service_protocols(server, allowed_bases)
         if available:
             eligible.append((sid, server, available))
     return eligible
+
+
+def _user_create_server_keyboard(eligible, lang: str = "en") -> dict:
+    rows = []
+    for sid, server, protos in eligible:
+        name = server.get("name") or server.get("host") or f"Server {sid + 1}"
+        proto_text = ", ".join(self_service_protocol_display_name(p) for p in protos)
+        rows.append([{"text": f"🖥 {name} ({proto_text})", "callback_data": _ref("user_create_server", {"sid": sid})}])
+    rows.append([{"text": f"❌ {_tt(lang, 'btn_cancel')}", "callback_data": "user_create_cancel"}])
+    return {"inline_keyboard": rows}
 
 
 def _build_connections_keyboard(conns: list, data: dict, lang: str = "en") -> dict:
@@ -610,9 +616,9 @@ def _protocols_keyboard(server_id: int, server: dict, lang: str = "en") -> dict:
 
 
 def _protocol_keyboard(server_id: int, proto: str, proto_info: dict, lang: str = "en") -> dict:
-    base = _proto_base(proto)
+    base = protocol_base(proto)
     rows = []
-    if base in CLIENT_PROTOCOLS:
+    if base in SELF_SERVICE_PROTOCOLS:
         rows.append([{"text": f" {_tt(lang, 'btn_connections')}", "callback_data": _ref("clients", {"sid": server_id, "proto": proto})}])
         rows.append([{"text": f" {_tt(lang, 'btn_create_connection')}", "callback_data": _ref("add_client", {"sid": server_id, "proto": proto})}])
     is_running = proto_info.get("container_running") is True
@@ -656,7 +662,7 @@ def _get_ssh_and_manager(server: dict, proto: str):
         server.get("password", ""),
         server.get("private_key", ""),
     )
-    base = _proto_base(proto)
+    base = protocol_base(proto)
     if base == "xray":
         manager = XrayManager(ssh, proto)
     elif base == "telemt":
@@ -869,7 +875,7 @@ async def _send_config_by_client(api: TelegramAPI, chat_id: int, server: dict, p
         server_name = server.get("name") or server.get("host", "Unknown")
         await api.send_message(chat_id, f"✅ <b>{_e(conn_name)}</b>\n🌐 {_tt(lang, 'servers_title')}: <b>{_e(server_name)}</b>\n🔌 {_tt(lang, 'protocol_label')}: <b>{_e(proto.upper())}</b>")
 
-        is_link_proto = _proto_base(proto) in ("xray", "telemt")
+        is_link_proto = protocol_base(proto) in ("xray", "telemt")
         if is_link_proto:
             await api.send_message(chat_id, f"🔗 <b>{_tt(lang, 'connection_link_label')}</b> (tap to copy):\n<code>{_e(config)}</code>")
         else:
@@ -1179,9 +1185,9 @@ async def _admin_create_client(api: TelegramAPI, chat_id: int, message_id: int, 
         ssh, manager = _get_ssh_and_manager(server, proto)
         try:
             ssh.connect()
-            if _proto_base(proto) == "telemt":
+            if protocol_base(proto) == "telemt":
                 result = manager.add_client(proto, name, server["host"], port)
-            elif _proto_base(proto) == "wireguard":
+            elif protocol_base(proto) == "wireguard":
                 result = manager.add_client(name, server["host"])
             else:
                 result = manager.add_client(proto, name, server["host"], port)
@@ -1220,7 +1226,7 @@ async def _admin_create_client(api: TelegramAPI, chat_id: int, message_id: int, 
 
 async def _send_config_text(api: TelegramAPI, chat_id: int, server: dict, proto: str, conn_name: str, config: str, generate_vpn_link_fn: Callable, lang: str = "en"):
     await api.send_message(chat_id, f"✅ <b>{_e(conn_name)}</b>\n🌐 {_tt(lang, 'servers_title')}: <b>{_e(server.get('name') or server.get('host'))}</b>\n {_tt(lang, 'protocol_label')}: <b>{_e(proto.upper())}</b>")
-    if _proto_base(proto) in ("xray", "telemt"):
+    if protocol_base(proto) in ("xray", "telemt"):
         await api.send_message(chat_id, f"🔗 <b>{_tt(lang, 'connection_link_label')}</b>:\n<code>{_e(config)}</code>")
     else:
         await api.send_message(chat_id, f"<b>📄 Configuration:</b>\n<pre>{_e(config)}</pre>")
@@ -1369,19 +1375,11 @@ async def _user_create_start(api: TelegramAPI, chat_id: int, message_id: int, ca
         return
 
     await api.answer_callback(callback_id)
-
-    rows = []
-    for sid, server, protos in eligible:
-        name = server.get("name") or server.get("host") or f"Server {sid + 1}"
-        proto_text = ", ".join(_protocol_display_name(p) for p in protos)
-        rows.append([{"text": f"🖥 {name} ({proto_text})", "callback_data": _ref("user_create_server", {"sid": sid})}])
-    rows.append([{"text": f"❌ {_tt(lang, 'btn_cancel')}", "callback_data": "user_create_cancel"}])
-
     await api.edit_message(
         chat_id,
         message_id,
         f"➕ <b>{_tt(lang, 'btn_create_connection')}</b>\n\n{_tt(lang, 'choose_server')}",
-        reply_markup={"inline_keyboard": rows},
+        reply_markup=_user_create_server_keyboard(eligible, lang),
     )
 
 
@@ -1401,17 +1399,10 @@ async def _user_create_start_message(api: TelegramAPI, chat_id: int, tg_id: str,
         await api.send_message(chat_id, _tt(lang, "self_service_no_servers"))
         return
 
-    rows = []
-    for sid, server, protos in eligible:
-        name = server.get("name") or server.get("host") or f"Server {sid + 1}"
-        proto_text = ", ".join(_protocol_display_name(p) for p in protos)
-        rows.append([{"text": f"🖥 {name} ({proto_text})", "callback_data": _ref("user_create_server", {"sid": sid})}])
-    rows.append([{"text": f"❌ {_tt(lang, 'btn_cancel')}", "callback_data": "user_create_cancel"}])
-
     await api.send_message(
         chat_id,
         f"➕ <b>{_tt(lang, 'btn_create_connection')}</b>\n\n{_tt(lang, 'choose_server')}",
-        reply_markup={"inline_keyboard": rows},
+        reply_markup=_user_create_server_keyboard(eligible, lang),
     )
 
 
@@ -1439,8 +1430,8 @@ async def _user_create_server(api: TelegramAPI, chat_id: int, message_id: int, c
         await api.edit_message(chat_id, message_id, _tt(lang, "server_not_self_service"))
         return
 
-    allowed_protocols = set(data.get("settings", {}).get("self_service", {}).get("allowed_protocols", []) or []) & {"awg", "awg2"}
-    available_protos = [p for p in ("awg", "awg2") if p in allowed_protocols and p in server.get("protocols", {})]
+    allowed_bases = sanitize_allowed_protocols(_self_service_settings(data).get("allowed_protocols", []))
+    available_protos = server_self_service_protocols(server, allowed_bases)
     if not available_protos:
         await api.edit_message(chat_id, message_id, _tt(lang, "no_protocols_available"))
         return

--- a/templates/my_connections.html
+++ b/templates/my_connections.html
@@ -169,15 +169,11 @@
         }[ch]));
     }
 
-    function getProtocolLabel(proto) {
-        const labels = {
-            awg: 'AmneziaWG',
-            awg2: 'AmneziaWG 2.0',
-            awg_legacy: 'AWG Legacy',
-            xray: 'Xray',
-            telemt: 'Telemt'
-        };
-        return labels[proto] || (proto || '').toUpperCase();
+    function getProtocolLabel(proto, protocolName) {
+        if (protocolName) {
+            return protocolName;
+        }
+        return String(proto || '').split('__', 1)[0].toUpperCase() || '—';
     }
 
     async function loadConnections() {
@@ -226,7 +222,7 @@
                     <div class="client-name" style="margin-bottom: 4px;">${escapeHtml(c.name || _('my_connections_title'))}</div>
                     <div class="client-meta" style="display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap;">
                         <span>🖥 ${escapeHtml(c.server_name || '—')}</span>
-                        <span style="color: var(--text-muted);">${escapeHtml(getProtocolLabel(c.protocol))}</span>
+                        <span style="color: var(--text-muted);">${escapeHtml(getProtocolLabel(c.protocol, c.protocol_name))}</span>
                     </div>
                 </div>
                 <button class="btn btn-secondary btn-sm btn-icon"

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -454,13 +454,12 @@
                     </div>
                     <div class="form-group">
                         <label class="form-label">{{ _('self_service_protocols') }}</label>
-                        <div class="flex gap-md" style="display:flex; gap:var(--space-md);">
+                        <div class="flex gap-md" style="display:flex; gap:var(--space-md); flex-wrap:wrap;">
+                            {% for choice in self_service_protocol_choices %}
                             <label style="display:flex; align-items:center; gap:var(--space-sm);">
-                                <input type="checkbox" id="ss_proto_awg" {% if 'awg' in settings.self_service.allowed_protocols | default(['awg']) %}checked{% endif %}> AWG
+                                <input type="checkbox" name="ss_proto" value="{{ choice.id }}" {% if choice.id in settings.self_service.allowed_protocols | default(['awg', 'awg2']) %}checked{% endif %}> {{ choice.name }}
                             </label>
-                            <label style="display:flex; align-items:center; gap:var(--space-sm);">
-                                <input type="checkbox" id="ss_proto_awg2" {% if 'awg2' in settings.self_service.allowed_protocols | default([]) %}checked{% endif %}> AWG 2.0
-                            </label>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>
@@ -907,10 +906,7 @@
             max_connections_per_user: parseInt(document.getElementById('ss_max_connections').value || '5'),
             rate_limit_count: parseInt(document.getElementById('ss_rate_limit').value || '3'),
             rate_limit_window_seconds: parseInt(document.getElementById('ss_rate_window').value || '60'),
-            allowed_protocols: [
-                ...(document.getElementById('ss_proto_awg').checked ? ['awg'] : []),
-                ...(document.getElementById('ss_proto_awg2').checked ? ['awg2'] : []),
-            ],
+            allowed_protocols: Array.from(document.querySelectorAll('input[name="ss_proto"]:checked')).map(el => el.value),
         };
 
         try {

--- a/tests/test_connection_service.py
+++ b/tests/test_connection_service.py
@@ -127,7 +127,7 @@ class ConnectionServiceTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(options['remaining_connections'], 5)
         self.assertEqual(
             options['servers'],
-            [{'id': 0, 'name': 'Server 1', 'protocols': [{'protocol': 'awg', 'name': 'AWG'}]}],
+            [{'id': 0, 'name': 'Server 1', 'protocols': [{'protocol': 'awg', 'name': 'AmneziaWG'}]}],
         )
 
     async def test_create_rejects_when_user_reaches_max_connections(self):
@@ -371,6 +371,99 @@ class ConnectionServiceTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(state['users'][0]['enabled'])
         self.assertEqual(state['user_connections'], [])
         self.assertEqual(fake_manager.removed, [('awg', 'client-1')])
+
+    async def test_options_includes_allowed_protocols_when_installed(self):
+        data = base_data()
+        data['settings']['self_service']['allowed_protocols'] = ['awg', 'xray', 'awg3']
+        data['servers'][0]['protocols'] = {
+            'awg': {'port': '55424'},
+            'xray': {'port': '443'},
+            'awg3': {'port': '55426'},
+        }
+        service, _, _ = self.make_service(data)
+
+        options = await service.get_self_service_options('user-1', 'web')
+        protos = [p['protocol'] for p in options['servers'][0]['protocols']]
+
+        self.assertEqual(protos, ['awg', 'xray', 'awg3'])
+
+    async def test_options_omits_protocols_not_in_allowlist(self):
+        data = base_data()
+        data['servers'][0]['protocols'] = {
+            'awg': {'port': '55424'},
+            'xray': {'port': '443'},
+        }
+        service, _, _ = self.make_service(data)
+
+        options = await service.get_self_service_options('user-1', 'web')
+        protos = [p['protocol'] for p in options['servers'][0]['protocols']]
+
+        self.assertEqual(protos, ['awg'])
+        self.assertNotIn('xray', protos)
+
+    async def test_options_includes_extra_protocol_instances(self):
+        data = base_data()
+        data['servers'][0]['protocols'] = {
+            'awg': {'port': '55424'},
+            'awg__2': {'port': '55425'},
+        }
+        service, _, _ = self.make_service(data)
+
+        options = await service.get_self_service_options('user-1', 'web')
+        protos = [p['protocol'] for p in options['servers'][0]['protocols']]
+
+        self.assertEqual(protos, ['awg', 'awg__2'])
+        self.assertEqual(
+            next(p['name'] for p in options['servers'][0]['protocols'] if p['protocol'] == 'awg__2'),
+            'AmneziaWG #2',
+        )
+
+    async def test_options_excludes_infrastructure_protocols(self):
+        data = base_data()
+        data['settings']['self_service']['allowed_protocols'] = [
+            'awg', 'dns', 'socks5', 'adguard', 'nginx',
+        ]
+        data['servers'][0]['protocols'] = {
+            'awg': {'port': '55424'},
+            'dns': {'port': '53'},
+            'socks5': {'port': '1080'},
+        }
+        service, _, _ = self.make_service(data)
+
+        options = await service.get_self_service_options('user-1', 'web')
+        protos = [p['protocol'] for p in options['servers'][0]['protocols']]
+
+        self.assertEqual(protos, ['awg'])
+
+    async def test_create_succeeds_for_xray(self):
+        data = base_data()
+        data['settings']['self_service']['allowed_protocols'] = ['awg', 'xray']
+        service, state, _ = self.make_service(data)
+
+        result = await service.create_user_connection('user-1', 0, 'xray', 'laptop', 'web')
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['connection']['protocol'], 'xray')
+
+    async def test_create_succeeds_for_extra_awg_instance(self):
+        data = base_data()
+        data['servers'][0]['protocols']['awg__2'] = {'port': '55425'}
+        service, state, _ = self.make_service(data)
+
+        result = await service.create_user_connection('user-1', 0, 'awg__2', 'tablet', 'web')
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['connection']['protocol'], 'awg__2')
+
+    async def test_create_rejects_protocol_not_in_allowlist(self):
+        data = base_data()
+        data['servers'][0]['protocols']['xray'] = {'port': '443'}
+        service, _, _ = self.make_service(data)
+
+        with self.assertRaises(SelfServiceError) as ctx:
+            await service.create_user_connection('user-1', 0, 'xray', 'home', 'web')
+
+        self.assertIn('not allowed', str(ctx.exception).lower())
 
 
 if __name__ == '__main__':

--- a/tests/test_telegram_self_service.py
+++ b/tests/test_telegram_self_service.py
@@ -204,6 +204,24 @@ class TestUserCreateServerCallback(unittest.IsolatedAsyncioTestCase):
         self.assertIn('AmneziaWG', keyboard_text)
         self.assertIn('AmneziaWG 2.0', keyboard_text)
 
+    async def test_user_create_server_shows_xray_when_allowed_and_installed(self):
+        self.data['settings']['self_service']['allowed_protocols'] = ['awg', 'awg2', 'xray']
+        payload = {'sid': 0}
+        ref_key = tg_bot._ref('user_create_server', payload)
+        msg = _callback_update(chat_id=111, from_id=111, data_str=ref_key)
+        await _dispatch_callback(self.api, msg, self.load_data)
+        keyboard_text = json.dumps(self.api.edit_message.call_args[1].get('reply_markup', {}))
+        self.assertIn('Xray', keyboard_text)
+
+    async def test_user_create_server_shows_extra_protocol_instance(self):
+        self.data['servers'][0]['protocols']['awg__2'] = {'port': '55426'}
+        payload = {'sid': 0}
+        ref_key = tg_bot._ref('user_create_server', payload)
+        msg = _callback_update(chat_id=111, from_id=111, data_str=ref_key)
+        await _dispatch_callback(self.api, msg, self.load_data)
+        keyboard_text = json.dumps(self.api.edit_message.call_args[1].get('reply_markup', {}))
+        self.assertIn('AmneziaWG #2', keyboard_text)
+
     async def test_user_create_protocol_panel_uses_russian_when_telegram_language_is_ru(self):
         ref_key = tg_bot._ref('user_create_protocol', {'sid': 0, 'proto': 'awg2'})
         msg = _callback_update(chat_id=111, from_id=111, data_str=ref_key, language_code='ru')


### PR DESCRIPTION
### Summary
Self-service was hardcoded to awg and awg2, so users could not create connections for other installed client protocols (AWG 3.1, AWG Legacy, Xray, Telemt, WireGuard).

This PR centralizes self-service protocol handling in connection_service.py and wires it through the web panel, Telegram bot, and settings UI. Admins still control which protocol families are allowed; users see only the protocol keys actually installed on each self-service-enabled server.