### PR TITLE
ci: run the unittest suite on push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run unit tests
+      run: python -m unittest discover -s tests -v


### PR DESCRIPTION
## The problem

`tests/` holds 70 stdlib `unittest` cases (`test_connection_service`, `test_my_connections_page`, `test_telegram_self_service`), but the only workflow, `build.yml`, builds PyInstaller binaries and Docker images — nothing ever runs the tests, so a regression cannot fail a pull request.

## The fix

A minimal `Tests` workflow (`.github/workflows/test.yml`): checkout, Python 3.11 (same as `build.yml`), `pip install -r requirements.txt`, `python -m unittest discover -s tests -v`. Runs on pushes to `main`, on every pull request and via `workflow_dispatch`; `permissions: contents: read`. No change to the build/release workflow.

I am preparing a series of PRs that lean on unit tests (golden-string tests for the generated container scripts, service tests with fake SSH); they are only meaningful if CI actually runs them, hence this one first.

## Testing

Locally from the repo root: `python -m unittest discover -s tests -v` → `Ran 70 tests … OK`. Same workflow on my fork: https://github.com/helldweller/Amnezia-Web-Panel/actions/runs/33777131603 (21 s, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)