### PR TITLE
fix(awg): invalidate the server-config cache after rewriting the config

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1383,6 +1383,13 @@ done < "$BW"
         self._server_config_cache[protocol_type] = (time.time(), out)
         return out
 
+    def _invalidate_config_cache(self, protocol_type):
+        """Forget the cached server config after the file in the container was
+        rewritten. Every writer must call this, otherwise a second read on the
+        same manager instance within _CACHE_TTL returns the pre-write content
+        (a peer removed and re-added in one go would be resurrected)."""
+        self._server_config_cache.pop(protocol_type, None)
+
     @staticmethod
     def _sanitize_server_config(config_content):
         """awg-quick chokes on a bare `DNS =` key in the server config (it calls
@@ -1629,6 +1636,7 @@ tail -f /dev/null
             f"docker cp /tmp/_amnz_add_peer.conf {container_name}:{config_path}"
         )
         self.ssh.run_command("rm -f /tmp/_amnz_add_peer.conf")
+        self._invalidate_config_cache(protocol_type)
 
     def _extract_ipv4(self, value):
         """Extract the first IPv4 address from AllowedIPs/clientIp-like values."""
@@ -2237,6 +2245,7 @@ AllowedIPs = {allowed_ips}
             self.ssh.run_sudo_command(
                 f"docker exec -i {container_name} bash -c 'echo \"{escaped_peer}\" >> {config_path}'"
             )
+            self._invalidate_config_cache(protocol_type)
         else:
             # Remove peer from server config, but first persist its current
             # AllowedIPs so native/external clients can be enabled later.
@@ -2284,6 +2293,7 @@ AllowedIPs = {allowed_ips}
                 f"docker cp /tmp/_amnz_config.conf {container_name}:{config_path}"
             )
             self.ssh.run_command("rm -f /tmp/_amnz_config.conf")
+            self._invalidate_config_cache(protocol_type)
 
         # Sync config
         self.ssh.run_sudo_command(
@@ -2327,6 +2337,7 @@ AllowedIPs = {allowed_ips}
             f"docker cp /tmp/_amnz_config.conf {container_name}:{config_path}"
         )
         self.ssh.run_command("rm -f /tmp/_amnz_config.conf")
+        self._invalidate_config_cache(protocol_type)
 
         # Sync config
         self.ssh.run_sudo_command(
@@ -2482,6 +2493,7 @@ AllowedIPs = {allowed_ips}
             f"docker cp /tmp/_amnz_settings.conf {container_name}:{config_path}"
         )
         self.ssh.run_command("rm -f /tmp/_amnz_settings.conf")
+        self._invalidate_config_cache(protocol_type)
         if code != 0:
             raise RuntimeError(f"Failed to write server config: {err or out}")
 

--- a/tests/test_awg_config_cache.py
+++ b/tests/test_awg_config_cache.py
@@ -1,0 +1,150 @@
+import json
+import re
+import unittest
+
+from managers.awg_manager import AWGManager
+
+
+CONFIG_PATH = '/opt/amnezia/awg/awg0.conf'
+CLIENTS_TABLE = '/opt/amnezia/awg/clientsTable'
+
+SERVER_CONFIG = """[Interface]
+PrivateKey = SERVERPRIVATEKEY
+Address = 10.8.1.1/24
+ListenPort = 55424
+Jc = 3
+Jmin = 10
+Jmax = 30
+S1 = 15
+S2 = 18
+H1 = 1020325451
+H2 = 3288052141
+H3 = 1770004689
+H4 = 2528465083
+
+[Peer]
+PublicKey = PEER_A
+PresharedKey = PSK_A
+AllowedIPs = 10.8.1.2/32
+
+[Peer]
+PublicKey = PEER_B
+PresharedKey = PSK_B
+AllowedIPs = 10.8.1.3/32
+"""
+
+
+class FakeSSH:
+    """Minimal stand-in for SSHManager that keeps the container's files in
+    memory, so a config written by one manager call is what the next call
+    reads back - exactly what the real docker cp / cat round-trip does."""
+
+    def __init__(self, files):
+        self.files = dict(files)
+        self.uploads = {}
+        self.commands = []
+
+    def upload_file(self, content, remote_path):
+        self.uploads[remote_path] = content
+
+    def run_command(self, command, timeout=60):
+        self.commands.append(command)
+        return '', '', 0
+
+    def run_sudo_command(self, command, timeout=60):
+        self.commands.append(command)
+
+        m = re.search(r"docker cp (\S+) \S+?:(\S+)", command)
+        if m:
+            self.files[m.group(2)] = self.uploads[m.group(1)]
+            return '', '', 0
+
+        m = re.search(r"for p in (.+?); do", command)
+        if m:  # _resolve_config_path probe
+            for path in m.group(1).split():
+                if path in self.files:
+                    return path + '\n', '', 0
+            return '', '', 1
+
+        m = re.search(r"echo \"(.*)\" >> (\S+)'$", command, re.S)
+        if m:  # toggle_client enable path appends the peer in place
+            self.files[m.group(2)] = self.files.get(m.group(2), '') + m.group(1)
+            return '', '', 0
+
+        m = re.search(r"docker exec -i \S+ cp (\S+) (\S+)", command)
+        if m:
+            self.files[m.group(2)] = self.files[m.group(1)]
+            return '', '', 0
+
+        m = re.search(r"docker exec -i \S+ cat (\S+)", command)
+        if m:
+            if m.group(1) in self.files:
+                return self.files[m.group(1)], '', 0
+            return '', 'No such file or directory', 1
+
+        return '', '', 0
+
+
+def peer_block(pubkey, ip):
+    return f"\n[Peer]\nPublicKey = {pubkey}\nPresharedKey = PSK_X\nAllowedIPs = {ip}/32\n\n"
+
+
+class ServerConfigCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.ssh = FakeSSH({CONFIG_PATH: SERVER_CONFIG})
+        self.manager = AWGManager(self.ssh)
+
+    def test_next_ip_advances_after_peer_insert_on_same_manager(self):
+        first = self.manager._get_next_ip('awg')
+        self.assertEqual(first, '10.8.1.4')
+
+        self.manager._insert_peer_sorted('awg', peer_block('PEER_C', first))
+
+        # Same manager instance, well inside _CACHE_TTL: the allocator must see
+        # the peer it just wrote, not the cached pre-insert config.
+        self.assertEqual(self.manager._get_next_ip('awg'), '10.8.1.5')
+
+    def test_remove_client_is_visible_to_next_read(self):
+        self.manager._get_server_config('awg')  # warm the cache
+        self.manager.remove_client('awg', 'PEER_B')
+
+        config = self.manager._get_server_config('awg')
+        self.assertNotIn('PEER_B', config)
+        self.assertIn('PEER_A', config)
+
+    def test_remove_then_reinsert_does_not_resurrect_old_peer(self):
+        # The exit-node upsert: drop a peer and re-add it with a new key but
+        # the same address, all through one manager instance.
+        self.manager._get_server_config('awg')
+        self.manager.remove_client('awg', 'PEER_B')
+        self.manager._insert_peer_sorted('awg', peer_block('PEER_B2', '10.8.1.3'))
+
+        config = self.ssh.files[CONFIG_PATH]
+        self.assertNotIn('PEER_B\n', config)
+        self.assertEqual(config.count('AllowedIPs = 10.8.1.3/32'), 1)
+        self.assertEqual(config.count('[Peer]'), 2)
+
+    def test_toggle_client_refreshes_cache_in_both_directions(self):
+        self.ssh.files[CLIENTS_TABLE] = json.dumps([{
+            'clientId': 'PEER_B',
+            'userData': {'clientName': 'b', 'clientIp': '10.8.1.3', 'psk': 'PSK_B', 'enabled': True},
+        }])
+        self.manager._get_server_config('awg')
+
+        self.manager.toggle_client('awg', 'PEER_B', False)
+        self.assertNotIn('PEER_B', self.manager._get_server_config('awg'))
+
+        self.manager.toggle_client('awg', 'PEER_B', True)
+        self.assertIn('PEER_B', self.manager._get_server_config('awg'))
+
+    def test_write_server_config_refreshes_cache(self):
+        self.manager._get_server_config('awg')
+        new_config = SERVER_CONFIG.replace('Jc = 3', 'Jc = 7')
+
+        self.manager._write_server_config('awg', new_config)
+
+        self.assertIn('Jc = 7', self.manager._get_server_config('awg'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

`AWGManager` caches the server config for 10 s (`_server_config_cache`, `_CACHE_TTL`), but only `save_server_config()` drops that cache around a write. The other five writers rewrite `awg0.conf` inside the container and leave the stale copy in place:

- `_insert_peer_sorted` (`docker cp`)
- `toggle_client`, enable branch (`echo … >> awg0.conf`) and disable branch (`docker cp`)
- `remove_client` (`docker cp`)
- `_write_server_config` (`docker cp`, used by `update_awg_settings`)

A second read on the **same manager instance** within the TTL therefore returns the pre-write content: `_get_next_ip()` hands out the address it just assigned, and a peer removed and re-added through one instance is resurrected from the cached text (two `[Peer]` blocks with the same `AllowedIPs`).

Today every API call and every bulk-operation iteration builds a fresh manager, so the window is confined to a single request and does not surface through the UI. It is the same class of problem as #79, and any code that issues two writes through one manager (e.g. a remove + re-add of a peer in one operation, which I need for an upcoming feature) runs straight into it — hence a small standalone fix.

## The fix

`_invalidate_config_cache(protocol_type)` pops the cached content; it is called right after each of the five writes. `save_server_config()` keeps its existing pops. 12 lines in `managers/awg_manager.py`, no behaviour change for callers.

## Testing

New `tests/test_awg_config_cache.py` drives the real `_get_next_ip` / `_insert_peer_sorted` / `remove_client` / `toggle_client` / `_write_server_config` against a `FakeSSH` that keeps the container's files in memory (handles `docker cp`, `cat`, the `for p in …` config-path probe, `cp` backups and the `echo >>` append). Five cases:

- next IP advances after an insert on the same instance (`.4` → `.5`)
- a removed peer is gone from the next read
- remove + re-insert with the same address yields exactly one `[Peer]` block
- disable/enable via `toggle_client` is visible to the next read in both directions
- `_write_server_config` is visible to the next read

Without the manager change all five fail; with it `python -m unittest discover -s tests` → 75 tests OK (CI run on my fork: https://github.com/helldweller/Amnezia-Web-Panel/actions/runs/33780221426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)