### PR TITLE
feat(servers): stable uid on every server record

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Configuration panel for system parameters and preferences:
     *   **NGINX + Let's Encrypt**: Reverse-proxy and HTTPS automation with certificate management for secure public endpoints.
 *   **⚙️ Core Server Management**:
     *   **Add / Edit / Delete / Reorder** server entries — drag-and-drop reorder updates `server_id` references in saved connections automatically.
+    *   Every server carries a stable `uid` (assigned on add and backfilled for existing records at startup) for cross-server references that must survive reorder and delete.
     *   **Live ping indicator** next to each server name — non-blocking TCP-connect probe to the SSH port, runs on the asyncio loop in parallel for all servers.
     *   **Clear server** wipes every Amnezia-related container, image and `/opt/amnezia` directory in a single sudo script — works for any current or future `amnezia-*` protocol.
     *   **Reboot** the server directly from the UI.

--- a/app.py
+++ b/app.py
@@ -935,6 +935,31 @@ BASE_PROTOCOLS = ['awg', 'awg2', 'awg3', 'awg_legacy', 'xray', 'telemt', 'dns', 
 MULTI_INSTANCE_PROTOCOLS = {'awg', 'awg2', 'awg3', 'awg_legacy', 'xray', 'telemt', 'socks5'}
 
 
+def backfill_server_uids(servers) -> bool:
+    """Give every server record without a stable `uid` one; return True when
+    something changed. Only write paths call this (startup migration,
+    add-server, backup restore): minting ids inside load_data() would let two
+    concurrent readers hand out different uids for the same record."""
+    changed = False
+    for server in servers or []:
+        if not server.get('uid'):
+            server['uid'] = uuid.uuid4().hex
+            changed = True
+    return changed
+
+
+def find_server_by_uid(data, uid):
+    """Return (index, server) for a stable server uid, or (None, None) when the
+    uid is empty or unknown. Index-based server_id values shift on reorder and
+    delete, so cross-server references must resolve through this instead."""
+    if not uid:
+        return None, None
+    for idx, server in enumerate(data.get('servers', []) or []):
+        if server.get('uid') == uid:
+            return idx, server
+    return None, None
+
+
 def protocol_base(protocol: str) -> str:
     return str(protocol or 'awg').split('__', 1)[0]
 
@@ -2288,6 +2313,11 @@ async def startup():
         changed = True
         logger.info("Initialised empty api_tokens collection")
 
+    # Stable server identity: list indices shift on reorder/delete, uids don't.
+    if backfill_server_uids(data.get('servers')):
+        changed = True
+        logger.info("Assigned uids to servers that had none")
+
     # Auto backup settings migration
     auto_backup = data.setdefault('settings', {}).setdefault('auto_backup', {})
     if 'enabled' not in auto_backup:
@@ -2743,6 +2773,7 @@ async def api_add_server(request: Request, req: AddServerRequest):
             return JSONResponse({'error': f'Connection failed: {str(e)}'}, status_code=400)
 
         server = {
+            'uid': uuid.uuid4().hex,
             'name': name, 'host': host, 'ssh_port': req.ssh_port,
             'username': username, 'password': req.password,
             'private_key': req.private_key, 'server_info': server_info,
@@ -5026,7 +5057,9 @@ async def api_backup_restore(request: Request, file: UploadFile = File(...)):
         if not isinstance(backup_data['servers'], list) or not isinstance(backup_data['users'], list):
             return JSONResponse({'error': 'Invalid structure: servers and users must be lists'}, status_code=400)
 
-        # Save the new data
+        # Save the new data; older backups predate server uids, mint them now
+        # so the file on disk is complete without waiting for the next restart.
+        backfill_server_uids(backup_data['servers'])
         async with DATA_LOCK:
             save_data(backup_data)
         

--- a/tests/test_server_uid.py
+++ b/tests/test_server_uid.py
@@ -1,0 +1,78 @@
+import re
+import unittest
+
+from app import backfill_server_uids, find_server_by_uid
+
+
+def servers():
+    return [
+        {'name': 'a', 'host': '10.0.0.1', 'protocols': {}},
+        {'name': 'b', 'host': '10.0.0.2', 'protocols': {}, 'uid': 'f' * 32},
+        {'name': 'c', 'host': '10.0.0.3', 'protocols': {}},
+    ]
+
+
+class BackfillServerUidsTests(unittest.TestCase):
+    def test_mints_distinct_uids_only_where_missing(self):
+        items = servers()
+
+        self.assertTrue(backfill_server_uids(items))
+
+        uids = [s['uid'] for s in items]
+        self.assertEqual(uids[1], 'f' * 32)  # existing value untouched
+        self.assertEqual(len(set(uids)), 3)
+        for uid in uids:
+            self.assertRegex(uid, r'^[0-9a-f]{32}$')
+
+    def test_is_idempotent(self):
+        items = servers()
+        backfill_server_uids(items)
+        before = [s['uid'] for s in items]
+
+        self.assertFalse(backfill_server_uids(items))
+        self.assertEqual([s['uid'] for s in items], before)
+
+    def test_tolerates_missing_list(self):
+        self.assertFalse(backfill_server_uids(None))
+        self.assertFalse(backfill_server_uids([]))
+
+
+class FindServerByUidTests(unittest.TestCase):
+    def setUp(self):
+        self.data = {'servers': servers()}
+        backfill_server_uids(self.data['servers'])
+
+    def test_resolves_index_and_record(self):
+        target = self.data['servers'][2]
+
+        idx, server = find_server_by_uid(self.data, target['uid'])
+
+        self.assertEqual(idx, 2)
+        self.assertIs(server, target)
+
+    def test_empty_or_unknown_uid_resolves_to_nothing(self):
+        self.assertEqual(find_server_by_uid(self.data, ''), (None, None))
+        self.assertEqual(find_server_by_uid(self.data, None), (None, None))
+        self.assertEqual(find_server_by_uid(self.data, 'no-such-uid'), (None, None))
+        self.assertEqual(find_server_by_uid({}, 'x'), (None, None))
+
+    def test_survives_reorder_and_delete(self):
+        target = self.data['servers'][2]
+        uid = target['uid']
+
+        # /api/servers/reorder rebuilds the list from a permutation of indices
+        order = [2, 0, 1]
+        self.data['servers'] = [self.data['servers'][i] for i in order]
+        idx, server = find_server_by_uid(self.data, uid)
+        self.assertEqual(idx, 0)
+        self.assertIs(server, target)
+
+        # /api/servers/{id}/delete pops a record and shifts the ones after it
+        self.data['servers'].pop(0)
+        self.assertEqual(find_server_by_uid(self.data, uid), (None, None))
+        other = self.data['servers'][1]
+        self.assertEqual(find_server_by_uid(self.data, other['uid']), (1, other))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

A server is identified by its position in `data['servers']`. `/api/servers/reorder` rebuilds the list from a permutation and remaps `user_connections[].server_id` and `settings.sync.remnawave_server_id`; `/api/servers/{id}/delete` pops the record and shifts the indices after it. Any *new* cross-server reference stored by index — e.g. a server that sends its traffic through another panel server, which I am working on — would silently point at the wrong host after either operation, unless every such place is taught about the remap too.

## The fix

Every server record gets a stable `uid` (`uuid4().hex`):

- `backfill_server_uids(servers)` — assigns a uid where missing, returns whether anything changed. It is called only from **write paths**: the `startup()` migration (persisted through the existing `changed` → `save_data` flow), `api_add_server` (new records get one immediately) and `/api/settings/backup/restore` (an old backup gets uids on disk right away). It is deliberately **not** called from `load_data()`: that function runs on every request and from background loops without `DATA_LOCK`, so two concurrent readers would mint different uids for the same record and whichever saved last would win.
- `find_server_by_uid(data, uid)` → `(index, server)`, or `(None, None)` for an empty/unknown uid, so a record that predates the migration can never be linked by accident.
- `api_edit_server` mutates fields in place, so an existing uid survives edits; reorder moves whole records, so it travels with them.

No behaviour change for anything that exists today; nothing reads `uid` yet except the tests. README gets one line under *Core Server Management*. Single commit on top of `main`, independent of #119/#121.

## Testing

`tests/test_server_uid.py` (6 cases): backfill mints distinct 32-hex uids only where missing and keeps an existing one; it is idempotent; tolerates `None`/`[]`; `find_server_by_uid` resolves index + record, returns `(None, None)` for `''`/`None`/unknown/empty data, and still resolves the same record after a reorder permutation and after a delete that shifts indices.

`python -m unittest discover -s tests` → 81 tests OK (fork CI: https://github.com/helldweller/Amnezia-Web-Panel/actions/runs/33787694647). Deployed on my panel: existing servers gain a `uid` on first start (`Assigned uids to servers that had none`), reorder keeps them, a newly added server gets one immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)