### PR TITLE
refactor(awg): builders for the Dockerfile, docker run and start script

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -875,50 +875,9 @@ done
         results.append("Pulling Docker image...")
         dockerfile_folder = f"/opt/amnezia/{container_name}"
 
-        # Create Dockerfile - matches original from client/server_scripts/awg/
-        dockerfile_content = (
-            f"FROM {docker_image}\n"
-            f"\n"
-            f'LABEL maintainer="AmneziaVPN"\n'
-            f"\n"
-            f"RUN apk add --no-cache bash curl dumb-init iptables\n"
-            f"RUN apk --update upgrade --no-cache\n"
-            f"\n"
-            # Only the AWG images ship awg-quick; the legacy one runs wg-quick
-            # against the plain WireGuard module, which has nothing to fall
-            # back to.
-            f"{AWG_QUICK_FORCE_USERSPACE_PATCH if base_proto in (self.AWG, self.AWG2, self.AWG3) else ''}"
-            f"\n"
-            f"RUN mkdir -p /opt/amnezia\n"
-            f'RUN echo "#!/bin/bash" > /opt/amnezia/start.sh && '
-            f'echo "sysctl -p /etc/sysctl.conf 2>/dev/null || true" >> /opt/amnezia/start.sh && '
-            f'echo "tail -f /dev/null" >> /opt/amnezia/start.sh\n'
-            f"RUN chmod a+x /opt/amnezia/start.sh\n"
-            f"\n"
-            f"# Network tuning (mirrors AmneziaVPN container tuning)\n"
-            f"RUN printf '%s\\n' \\\n"
-            f"'fs.file-max = 51200' \\\n"
-            f"'net.core.rmem_max = 67108864' \\\n"
-            f"'net.core.wmem_max = 67108864' \\\n"
-            f"'net.core.netdev_max_backlog = 250000' \\\n"
-            f"'net.core.somaxconn = 4096' \\\n"
-            f"'net.ipv4.tcp_syncookies = 1' \\\n"
-            f"'net.ipv4.tcp_tw_reuse = 1' \\\n"
-            f"'net.ipv4.tcp_fin_timeout = 30' \\\n"
-            f"'net.ipv4.tcp_keepalive_time = 1200' \\\n"
-            f"'net.ipv4.ip_local_port_range = 10000 65000' \\\n"
-            f"'net.ipv4.tcp_max_syn_backlog = 8192' \\\n"
-            f"'net.ipv4.tcp_max_tw_buckets = 5000' \\\n"
-            f"'net.ipv4.tcp_fastopen = 3' \\\n"
-            f"'net.ipv4.tcp_mem = 25600 51200 102400' \\\n"
-            f"'net.ipv4.tcp_rmem = 4096 87380 67108864' \\\n"
-            f"'net.ipv4.tcp_wmem = 4096 65536 67108864' \\\n"
-            f"'net.ipv4.tcp_mtu_probing = 1' \\\n"
-            f" >> /etc/sysctl.conf && \\\n"
-            f"mkdir -p /etc/security && \\\n"
-            f"printf '%s\\n' '* soft nofile 51200' '* hard nofile 51200' >> /etc/security/limits.conf\n"
-            f"\n"
-            f'ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]\n'
+        dockerfile_content = self._dockerfile_content(
+            docker_image,
+            AWG_QUICK_FORCE_USERSPACE_PATCH if base_proto in (self.AWG, self.AWG2, self.AWG3) else '',
         )
         self.ssh.run_sudo_command(f"mkdir -p {dockerfile_folder}")
         self.ssh.upload_file_sudo(dockerfile_content, f"{dockerfile_folder}/Dockerfile")
@@ -934,28 +893,10 @@ done
         # Step 5: Run container
         results.append("Starting container...")
         # Detect host IPv6 BEFORE creating the container: the netns
-        # disable_ipv6 flags are fixed at container creation time, so a
-        # container started without these sysctls can never add an IPv6
-        # address to a tunnel interface (ip -6 address add -> RTNETLINK
-        # Permission denied, and awg-quick then deletes the whole awg0).
+        # disable_ipv6 flags are fixed at container creation time, see
+        # _docker_run_cmd.
         ipv6_enabled = self._detect_server_ipv6()
-        ipv6_sysctls = (
-            '--sysctl="net.ipv6.conf.all.disable_ipv6=0" \\\n'
-            '--sysctl="net.ipv6.conf.default.disable_ipv6=0" \\\n'
-            if ipv6_enabled else ''
-        )
-        run_cmd = f"""docker run -d \
---restart always \
---privileged \
---cap-add=NET_ADMIN \
---cap-add=SYS_MODULE \
--p {port}:{port}/udp \
--v /lib/modules:/lib/modules \
---sysctl="net.ipv4.conf.all.src_valid_mark=1" \
-{ipv6_sysctls} --name {container_name} \
---ulimit nofile=51200:51200 \
---name {container_name} \
-{container_name}"""
+        run_cmd = self._docker_run_cmd(container_name, container_name, port, ipv6_enabled)
 
         out, err, code = self.ssh.run_sudo_command(run_cmd)
         if code != 0:
@@ -983,7 +924,7 @@ done
 
         # Step 7: Upload and run start script
         results.append("Starting AWG service...")
-        self._upload_start_script(protocol_type, port, awg_params)
+        self._upload_start_script(protocol_type)
         self._verify_interface_up(protocol_type)
         results.append("AWG service started")
 
@@ -1138,14 +1079,92 @@ H4 = {awg_params['transport_packet_magic_header']}
         if code != 0:
             raise RuntimeError(f"Failed to configure container: {err}")
 
-    def _upload_start_script(self, protocol_type, port, awg_params):
-        """Upload and execute the start script inside the container."""
-        container_name = self._container_name(protocol_type)
-        quick_bin = self._quick_binary(protocol_type)
-        config_path = self._config_path(protocol_type)
-        userspace_guard = self._userspace_guard(protocol_type)
+    # ===================== CONTAINER BUILDERS =====================
+    # Pure string builders (no SSH), pinned by golden fixtures in
+    # tests/test_awg_start_script.py so the generated container files can be
+    # changed deliberately, never by accident.
 
-        start_script = f"""#!/bin/bash
+    @staticmethod
+    def _dockerfile_content(docker_image, userspace_patch):
+        """Dockerfile of a protocol container - matches the original from
+        client/server_scripts/awg/. `userspace_patch` is the awg-quick sed
+        patch for AWG images or '' for the legacy one (it runs wg-quick
+        against the plain WireGuard module, which has nothing to fall back
+        to)."""
+        return (
+            f"FROM {docker_image}\n"
+            f"\n"
+            f'LABEL maintainer="AmneziaVPN"\n'
+            f"\n"
+            f"RUN apk add --no-cache bash curl dumb-init iptables\n"
+            f"RUN apk --update upgrade --no-cache\n"
+            f"\n"
+            f"{userspace_patch}"
+            f"\n"
+            f"RUN mkdir -p /opt/amnezia\n"
+            f'RUN echo "#!/bin/bash" > /opt/amnezia/start.sh && '
+            f'echo "sysctl -p /etc/sysctl.conf 2>/dev/null || true" >> /opt/amnezia/start.sh && '
+            f'echo "tail -f /dev/null" >> /opt/amnezia/start.sh\n'
+            f"RUN chmod a+x /opt/amnezia/start.sh\n"
+            f"\n"
+            f"# Network tuning (mirrors AmneziaVPN container tuning)\n"
+            f"RUN printf '%s\\n' \\\n"
+            f"'fs.file-max = 51200' \\\n"
+            f"'net.core.rmem_max = 67108864' \\\n"
+            f"'net.core.wmem_max = 67108864' \\\n"
+            f"'net.core.netdev_max_backlog = 250000' \\\n"
+            f"'net.core.somaxconn = 4096' \\\n"
+            f"'net.ipv4.tcp_syncookies = 1' \\\n"
+            f"'net.ipv4.tcp_tw_reuse = 1' \\\n"
+            f"'net.ipv4.tcp_fin_timeout = 30' \\\n"
+            f"'net.ipv4.tcp_keepalive_time = 1200' \\\n"
+            f"'net.ipv4.ip_local_port_range = 10000 65000' \\\n"
+            f"'net.ipv4.tcp_max_syn_backlog = 8192' \\\n"
+            f"'net.ipv4.tcp_max_tw_buckets = 5000' \\\n"
+            f"'net.ipv4.tcp_fastopen = 3' \\\n"
+            f"'net.ipv4.tcp_mem = 25600 51200 102400' \\\n"
+            f"'net.ipv4.tcp_rmem = 4096 87380 67108864' \\\n"
+            f"'net.ipv4.tcp_wmem = 4096 65536 67108864' \\\n"
+            f"'net.ipv4.tcp_mtu_probing = 1' \\\n"
+            f" >> /etc/sysctl.conf && \\\n"
+            f"mkdir -p /etc/security && \\\n"
+            f"printf '%s\\n' '* soft nofile 51200' '* hard nofile 51200' >> /etc/security/limits.conf\n"
+            f"\n"
+            f'ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]\n'
+        )
+
+    @staticmethod
+    def _docker_run_cmd(container_name, image, port, ipv6_enabled):
+        """`docker run` command line of a protocol container.
+
+        The IPv6 sysctls have to be passed at creation time: the netns
+        disable_ipv6 flags are fixed then, so a container started without
+        them can never add an IPv6 address to a tunnel interface (ip -6
+        address add -> RTNETLINK Permission denied, and awg-quick then
+        deletes the whole awg0).
+        """
+        ipv6_sysctls = (
+            '--sysctl="net.ipv6.conf.all.disable_ipv6=0" \\\n'
+            '--sysctl="net.ipv6.conf.default.disable_ipv6=0" \\\n'
+            if ipv6_enabled else ''
+        )
+        return f"""docker run -d \
+--restart always \
+--privileged \
+--cap-add=NET_ADMIN \
+--cap-add=SYS_MODULE \
+-p {port}:{port}/udp \
+-v /lib/modules:/lib/modules \
+--sysctl="net.ipv4.conf.all.src_valid_mark=1" \
+{ipv6_sysctls} --name {container_name} \
+--ulimit nofile=51200:51200 \
+{image}"""
+
+    @staticmethod
+    def _start_script_body(config_path, quick_bin, userspace_guard, subnet_default, bwlimits_path):
+        """/opt/amnezia/start.sh of a protocol container: brings the tunnel
+        up, sets up forwarding/NAT and applies per-peer bandwidth limits."""
+        return f"""#!/bin/bash
 echo "Container startup"
 
 # Apply container network tuning (see Dockerfile)
@@ -1154,7 +1173,7 @@ sysctl -p /etc/sysctl.conf 2>/dev/null || true
 # Read subnet from server config dynamically (IPv4 part of the Address line)
 SUBNET=$(grep '^Address' {config_path} | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
 if [ -z "$SUBNET" ]; then
-  SUBNET={AWG_DEFAULTS['subnet_ip']}/{AWG_DEFAULTS['subnet_cidr']}
+  SUBNET={subnet_default}
 fi
 
 # IPv6 subnet, if the tunnel is dual-stack (second part of the Address line)
@@ -1195,24 +1214,39 @@ if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
 fi
 
 # Apply per-peer bandwidth limits (flat file written by the panel)
-if [ -f /opt/amnezia/awg/bwlimits ]; then
+if [ -f {bwlimits_path} ]; then
 (
-{self._tc_apply_body('/opt/amnezia/awg/bwlimits', config_path)}
+{AWGManager._tc_apply_body(bwlimits_path, config_path)}
 )
 fi
 
 tail -f /dev/null
 """
 
-        # Upload start script to container via SFTP + docker cp
-        self.ssh.upload_file(start_script, "/tmp/_amnz_start.sh")
+    def _render_start_script(self, protocol_type, config_path=None):
+        """start.sh for one protocol instance. `config_path` overrides the
+        default location - save_server_config passes the resolved path of an
+        existing container."""
+        return self._start_script_body(
+            config_path or self._config_path(protocol_type),
+            self._quick_binary(protocol_type),
+            self._userspace_guard(protocol_type),
+            f"{AWG_DEFAULTS['subnet_ip']}/{AWG_DEFAULTS['subnet_cidr']}",
+            self._bwlimits_path(),
+        )
+
+    def _write_start_script(self, protocol_type, config_path=None):
+        """Put a freshly rendered start.sh into the container (no restart)."""
+        container_name = self._container_name(protocol_type)
+        self.ssh.upload_file(self._render_start_script(protocol_type, config_path), "/tmp/_amnz_start.sh")
         self.ssh.run_sudo_command(f"docker cp /tmp/_amnz_start.sh {container_name}:/opt/amnezia/start.sh")
         self.ssh.run_sudo_command(f"docker exec {container_name} chmod +x /opt/amnezia/start.sh")
         self.ssh.run_command("rm -f /tmp/_amnz_start.sh")
 
-        # Restart to apply the start script
-        self.ssh.run_sudo_command(f"docker restart {container_name}")
-        import time
+    def _upload_start_script(self, protocol_type):
+        """Write the start script and restart the container to run it."""
+        self._write_start_script(protocol_type)
+        self.ssh.run_sudo_command(f"docker restart {self._container_name(protocol_type)}")
         time.sleep(5)
 
     def remove_container(self, protocol_type):
@@ -1413,70 +1447,7 @@ done < "$BW"
         self.ssh.run_command("rm -f /tmp/_amnz_edit_config.conf")
 
         # Regenerate start script so iptables rules pick up the (possibly changed) subnet
-        quick_bin = self._quick_binary(protocol_type)
-        userspace_guard = self._userspace_guard(protocol_type)
-        start_script = f"""#!/bin/bash
-echo "Container startup"
-
-# Apply container network tuning (see Dockerfile)
-sysctl -p /etc/sysctl.conf 2>/dev/null || true
-
-# Read subnet from server config dynamically (IPv4 part of the Address line)
-SUBNET=$(grep '^Address' {config_path} | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
-if [ -z "$SUBNET" ]; then
-  SUBNET={AWG_DEFAULTS['subnet_ip']}/{AWG_DEFAULTS['subnet_cidr']}
-fi
-
-# IPv6 subnet, if the tunnel is dual-stack (second part of the Address line)
-SUBNET6=$(grep '^Address' {config_path} | head -1 | tr ',' '\n' | grep ':' | sed 's/^[^=]*=//' | tr -d ' ' | head -1)
-{userspace_guard}
-# kill daemons in case of restart
-{quick_bin} down {config_path} 2>/dev/null
-
-# start daemons if configured
-if [ -f {config_path} ]; then {quick_bin} up {config_path}; fi
-
-# Allow traffic on the TUN interface
-IFACE=$(basename {config_path} .conf)
-iptables -A INPUT -i $IFACE -j ACCEPT
-iptables -A FORWARD -i $IFACE -j ACCEPT
-iptables -A OUTPUT -o $IFACE -j ACCEPT
-
-# Allow forwarding traffic only from the VPN
-iptables -A FORWARD -i $IFACE -o eth0 -s $SUBNET -j ACCEPT
-iptables -A FORWARD -i $IFACE -o eth1 -s $SUBNET -j ACCEPT
-
-iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-iptables -t nat -A POSTROUTING -s $SUBNET -o eth0 -j MASQUERADE
-iptables -t nat -A POSTROUTING -s $SUBNET -o eth1 -j MASQUERADE
-
-# IPv6 forwarding + NAT66, only when the tunnel has an IPv6 subnet
-if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
-  sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
-  ip6tables -A INPUT -i $IFACE -j ACCEPT
-  ip6tables -A FORWARD -i $IFACE -j ACCEPT
-  ip6tables -A OUTPUT -o $IFACE -j ACCEPT
-  ip6tables -A FORWARD -i $IFACE -o eth0 -s $SUBNET6 -j ACCEPT
-  ip6tables -A FORWARD -i $IFACE -o eth1 -s $SUBNET6 -j ACCEPT
-  ip6tables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
-  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth0 -j MASQUERADE
-  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
-fi
-
-# Apply per-peer bandwidth limits (flat file written by the panel)
-if [ -f /opt/amnezia/awg/bwlimits ]; then
-(
-{self._tc_apply_body('/opt/amnezia/awg/bwlimits', config_path)}
-)
-fi
-
-tail -f /dev/null
-"""
-        self.ssh.upload_file(start_script, "/tmp/_amnz_start.sh")
-        self.ssh.run_sudo_command(f"docker cp /tmp/_amnz_start.sh {container_name}:/opt/amnezia/start.sh")
-        self.ssh.run_sudo_command(f"docker exec {container_name} chmod +x /opt/amnezia/start.sh")
-        self.ssh.run_command("rm -f /tmp/_amnz_start.sh")
+        self._write_start_script(protocol_type, config_path)
 
         # Restart container to apply all changes (including port and interface changes)
         self.ssh.run_sudo_command(f"docker restart {container_name}")

--- a/tests/fixtures/docker_run_awg.txt
+++ b/tests/fixtures/docker_run_awg.txt
@@ -1,0 +1,1 @@
+docker run -d --restart always --privileged --cap-add=NET_ADMIN --cap-add=SYS_MODULE -p 55424:55424/udp -v /lib/modules:/lib/modules --sysctl="net.ipv4.conf.all.src_valid_mark=1"  --name amnezia-awg --ulimit nofile=51200:51200 --name amnezia-awg amnezia-awg

--- a/tests/fixtures/docker_run_awg_ipv6.txt
+++ b/tests/fixtures/docker_run_awg_ipv6.txt
@@ -1,0 +1,3 @@
+docker run -d --restart always --privileged --cap-add=NET_ADMIN --cap-add=SYS_MODULE -p 55424:55424/udp -v /lib/modules:/lib/modules --sysctl="net.ipv4.conf.all.src_valid_mark=1" --sysctl="net.ipv6.conf.all.disable_ipv6=0" \
+--sysctl="net.ipv6.conf.default.disable_ipv6=0" \
+ --name amnezia-awg --ulimit nofile=51200:51200 --name amnezia-awg amnezia-awg

--- a/tests/fixtures/dockerfile_awg.txt
+++ b/tests/fixtures/dockerfile_awg.txt
@@ -1,0 +1,37 @@
+FROM amneziavpn/amneziawg-go:latest
+
+LABEL maintainer="AmneziaVPN"
+
+RUN apk add --no-cache bash curl dumb-init iptables
+RUN apk --update upgrade --no-cache
+
+RUN sed -i 's|if ! cmd ip link add "$INTERFACE" type amneziawg; then|if [ -n "$WG_FORCE_USERSPACE" ]; then cmd "${WG_QUICK_USERSPACE_IMPLEMENTATION:-amneziawg-go}" "$INTERFACE"; return 0; fi; if ! cmd ip link add "$INTERFACE" type amneziawg; then|' /usr/bin/awg-quick && grep -q WG_FORCE_USERSPACE /usr/bin/awg-quick
+
+RUN mkdir -p /opt/amnezia
+RUN echo "#!/bin/bash" > /opt/amnezia/start.sh && echo "sysctl -p /etc/sysctl.conf 2>/dev/null || true" >> /opt/amnezia/start.sh && echo "tail -f /dev/null" >> /opt/amnezia/start.sh
+RUN chmod a+x /opt/amnezia/start.sh
+
+# Network tuning (mirrors AmneziaVPN container tuning)
+RUN printf '%s\n' \
+'fs.file-max = 51200' \
+'net.core.rmem_max = 67108864' \
+'net.core.wmem_max = 67108864' \
+'net.core.netdev_max_backlog = 250000' \
+'net.core.somaxconn = 4096' \
+'net.ipv4.tcp_syncookies = 1' \
+'net.ipv4.tcp_tw_reuse = 1' \
+'net.ipv4.tcp_fin_timeout = 30' \
+'net.ipv4.tcp_keepalive_time = 1200' \
+'net.ipv4.ip_local_port_range = 10000 65000' \
+'net.ipv4.tcp_max_syn_backlog = 8192' \
+'net.ipv4.tcp_max_tw_buckets = 5000' \
+'net.ipv4.tcp_fastopen = 3' \
+'net.ipv4.tcp_mem = 25600 51200 102400' \
+'net.ipv4.tcp_rmem = 4096 87380 67108864' \
+'net.ipv4.tcp_wmem = 4096 65536 67108864' \
+'net.ipv4.tcp_mtu_probing = 1' \
+ >> /etc/sysctl.conf && \
+mkdir -p /etc/security && \
+printf '%s\n' '* soft nofile 51200' '* hard nofile 51200' >> /etc/security/limits.conf
+
+ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]

--- a/tests/fixtures/dockerfile_awg_legacy.txt
+++ b/tests/fixtures/dockerfile_awg_legacy.txt
@@ -1,0 +1,36 @@
+FROM amneziavpn/amnezia-wg:latest
+
+LABEL maintainer="AmneziaVPN"
+
+RUN apk add --no-cache bash curl dumb-init iptables
+RUN apk --update upgrade --no-cache
+
+
+RUN mkdir -p /opt/amnezia
+RUN echo "#!/bin/bash" > /opt/amnezia/start.sh && echo "sysctl -p /etc/sysctl.conf 2>/dev/null || true" >> /opt/amnezia/start.sh && echo "tail -f /dev/null" >> /opt/amnezia/start.sh
+RUN chmod a+x /opt/amnezia/start.sh
+
+# Network tuning (mirrors AmneziaVPN container tuning)
+RUN printf '%s\n' \
+'fs.file-max = 51200' \
+'net.core.rmem_max = 67108864' \
+'net.core.wmem_max = 67108864' \
+'net.core.netdev_max_backlog = 250000' \
+'net.core.somaxconn = 4096' \
+'net.ipv4.tcp_syncookies = 1' \
+'net.ipv4.tcp_tw_reuse = 1' \
+'net.ipv4.tcp_fin_timeout = 30' \
+'net.ipv4.tcp_keepalive_time = 1200' \
+'net.ipv4.ip_local_port_range = 10000 65000' \
+'net.ipv4.tcp_max_syn_backlog = 8192' \
+'net.ipv4.tcp_max_tw_buckets = 5000' \
+'net.ipv4.tcp_fastopen = 3' \
+'net.ipv4.tcp_mem = 25600 51200 102400' \
+'net.ipv4.tcp_rmem = 4096 87380 67108864' \
+'net.ipv4.tcp_wmem = 4096 65536 67108864' \
+'net.ipv4.tcp_mtu_probing = 1' \
+ >> /etc/sysctl.conf && \
+mkdir -p /etc/security && \
+printf '%s\n' '* soft nofile 51200' '* hard nofile 51200' >> /etc/security/limits.conf
+
+ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]

--- a/tests/fixtures/start_awg.sh
+++ b/tests/fixtures/start_awg.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+echo "Container startup"
+
+# Apply container network tuning (see Dockerfile)
+sysctl -p /etc/sysctl.conf 2>/dev/null || true
+
+# Read subnet from server config dynamically (IPv4 part of the Address line)
+SUBNET=$(grep '^Address' /opt/amnezia/awg/awg0.conf | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
+if [ -z "$SUBNET" ]; then
+  SUBNET=10.8.1.1/24
+fi
+
+# IPv6 subnet, if the tunnel is dual-stack (second part of the Address line)
+SUBNET6=$(grep '^Address' /opt/amnezia/awg/awg0.conf | head -1 | tr ',' '
+' | grep ':' | sed 's/^[^=]*=//' | tr -d ' ' | head -1)
+
+# kill daemons in case of restart
+awg-quick down /opt/amnezia/awg/awg0.conf 2>/dev/null
+
+# start daemons if configured
+if [ -f /opt/amnezia/awg/awg0.conf ]; then awg-quick up /opt/amnezia/awg/awg0.conf; fi
+
+# Allow traffic on the TUN interface
+IFACE=$(basename /opt/amnezia/awg/awg0.conf .conf)
+iptables -A INPUT -i $IFACE -j ACCEPT
+iptables -A FORWARD -i $IFACE -j ACCEPT
+iptables -A OUTPUT -o $IFACE -j ACCEPT
+
+# Allow forwarding traffic only from the VPN
+iptables -A FORWARD -i $IFACE -o eth0 -s $SUBNET -j ACCEPT
+iptables -A FORWARD -i $IFACE -o eth1 -s $SUBNET -j ACCEPT
+
+iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth1 -j MASQUERADE
+
+# IPv6 forwarding + NAT66, only when the tunnel has an IPv6 subnet
+if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
+  sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+  ip6tables -A INPUT -i $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -j ACCEPT
+  ip6tables -A OUTPUT -o $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth0 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth1 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth0 -j MASQUERADE
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
+fi
+
+# Apply per-peer bandwidth limits (flat file written by the panel)
+if [ -f /opt/amnezia/awg/bwlimits ]; then
+(
+
+BW=/opt/amnezia/awg/bwlimits
+IFACE=$(basename /opt/amnezia/awg/awg0.conf .conf)
+[ -f "$BW" ] || exit 0
+command -v tc >/dev/null 2>&1 || exit 0
+ip link show dev $IFACE >/dev/null 2>&1 || exit 0
+tc qdisc del dev $IFACE root 2>/dev/null
+tc qdisc del dev $IFACE ingress 2>/dev/null
+tc qdisc add dev $IFACE root handle 1: htb default 0 2>/dev/null || exit 0
+tc qdisc add dev $IFACE handle ffff: ingress 2>/dev/null || true
+i=0
+while read -r ip4 ip6 mbps; do
+  [ -z "$ip4" ] && continue
+  [ -z "$mbps" ] && continue
+  kbit=$(echo "$mbps" | awk '{printf "%d", $1*1000}')
+  [ "$kbit" -gt 0 ] 2>/dev/null || continue
+  i=$((i+1))
+  cid=$((100+i))
+  tc class add dev $IFACE parent 1: classid 1:$cid htb rate ${kbit}kbit ceil ${kbit}kbit 2>/dev/null
+  tc filter add dev $IFACE parent 1: protocol ip u32 match ip dst $ip4/32 flowid 1:$cid 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent 1: protocol ipv6 u32 match ip6 dst $ip6/128 flowid 1:$cid 2>/dev/null
+  tc filter add dev $IFACE parent ffff: protocol ip u32 match ip src $ip4/32 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent ffff: protocol ipv6 u32 match ip6 src $ip6/128 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+done < "$BW"
+
+)
+fi
+
+tail -f /dev/null

--- a/tests/fixtures/start_awg3.sh
+++ b/tests/fixtures/start_awg3.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+echo "Container startup"
+
+# Apply container network tuning (see Dockerfile)
+sysctl -p /etc/sysctl.conf 2>/dev/null || true
+
+# Read subnet from server config dynamically (IPv4 part of the Address line)
+SUBNET=$(grep '^Address' /opt/amnezia/awg/awg0.conf | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
+if [ -z "$SUBNET" ]; then
+  SUBNET=10.8.1.1/24
+fi
+
+# IPv6 subnet, if the tunnel is dual-stack (second part of the Address line)
+SUBNET6=$(grep '^Address' /opt/amnezia/awg/awg0.conf | head -1 | tr ',' '
+' | grep ':' | sed 's/^[^=]*=//' | tr -d ' ' | head -1)
+
+# AWG 3.1 needs amneziawg kernel module 3.0+; an older one accepts the
+# interface but rejects the config, and awg-quick will not fall back once
+# `ip link add` has succeeded (issue #113).
+if ip link add awgprobe type amneziawg 2>/dev/null; then
+  KMOD_VERSION=$(cat /sys/module/amneziawg/version 2>/dev/null)
+  ip link delete awgprobe 2>/dev/null
+  case "$KMOD_VERSION" in
+    3.*|[4-9].*|[1-9][0-9].*) ;;
+    *) echo "amneziawg kernel module ${KMOD_VERSION:-unknown} predates AWG 3.1, using userspace amneziawg-go"
+       export WG_FORCE_USERSPACE=1 ;;
+  esac
+fi
+
+# kill daemons in case of restart
+awg-quick down /opt/amnezia/awg/awg0.conf 2>/dev/null
+
+# start daemons if configured
+if [ -f /opt/amnezia/awg/awg0.conf ]; then awg-quick up /opt/amnezia/awg/awg0.conf; fi
+
+# Allow traffic on the TUN interface
+IFACE=$(basename /opt/amnezia/awg/awg0.conf .conf)
+iptables -A INPUT -i $IFACE -j ACCEPT
+iptables -A FORWARD -i $IFACE -j ACCEPT
+iptables -A OUTPUT -o $IFACE -j ACCEPT
+
+# Allow forwarding traffic only from the VPN
+iptables -A FORWARD -i $IFACE -o eth0 -s $SUBNET -j ACCEPT
+iptables -A FORWARD -i $IFACE -o eth1 -s $SUBNET -j ACCEPT
+
+iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth1 -j MASQUERADE
+
+# IPv6 forwarding + NAT66, only when the tunnel has an IPv6 subnet
+if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
+  sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+  ip6tables -A INPUT -i $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -j ACCEPT
+  ip6tables -A OUTPUT -o $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth0 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth1 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth0 -j MASQUERADE
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
+fi
+
+# Apply per-peer bandwidth limits (flat file written by the panel)
+if [ -f /opt/amnezia/awg/bwlimits ]; then
+(
+
+BW=/opt/amnezia/awg/bwlimits
+IFACE=$(basename /opt/amnezia/awg/awg0.conf .conf)
+[ -f "$BW" ] || exit 0
+command -v tc >/dev/null 2>&1 || exit 0
+ip link show dev $IFACE >/dev/null 2>&1 || exit 0
+tc qdisc del dev $IFACE root 2>/dev/null
+tc qdisc del dev $IFACE ingress 2>/dev/null
+tc qdisc add dev $IFACE root handle 1: htb default 0 2>/dev/null || exit 0
+tc qdisc add dev $IFACE handle ffff: ingress 2>/dev/null || true
+i=0
+while read -r ip4 ip6 mbps; do
+  [ -z "$ip4" ] && continue
+  [ -z "$mbps" ] && continue
+  kbit=$(echo "$mbps" | awk '{printf "%d", $1*1000}')
+  [ "$kbit" -gt 0 ] 2>/dev/null || continue
+  i=$((i+1))
+  cid=$((100+i))
+  tc class add dev $IFACE parent 1: classid 1:$cid htb rate ${kbit}kbit ceil ${kbit}kbit 2>/dev/null
+  tc filter add dev $IFACE parent 1: protocol ip u32 match ip dst $ip4/32 flowid 1:$cid 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent 1: protocol ipv6 u32 match ip6 dst $ip6/128 flowid 1:$cid 2>/dev/null
+  tc filter add dev $IFACE parent ffff: protocol ip u32 match ip src $ip4/32 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent ffff: protocol ipv6 u32 match ip6 src $ip6/128 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+done < "$BW"
+
+)
+fi
+
+tail -f /dev/null

--- a/tests/fixtures/start_awg_legacy.sh
+++ b/tests/fixtures/start_awg_legacy.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+echo "Container startup"
+
+# Apply container network tuning (see Dockerfile)
+sysctl -p /etc/sysctl.conf 2>/dev/null || true
+
+# Read subnet from server config dynamically (IPv4 part of the Address line)
+SUBNET=$(grep '^Address' /opt/amnezia/awg/wg0.conf | head -1 | cut -d'=' -f2 | cut -d',' -f1 | tr -d ' ')
+if [ -z "$SUBNET" ]; then
+  SUBNET=10.8.1.1/24
+fi
+
+# IPv6 subnet, if the tunnel is dual-stack (second part of the Address line)
+SUBNET6=$(grep '^Address' /opt/amnezia/awg/wg0.conf | head -1 | tr ',' '
+' | grep ':' | sed 's/^[^=]*=//' | tr -d ' ' | head -1)
+
+# kill daemons in case of restart
+wg-quick down /opt/amnezia/awg/wg0.conf 2>/dev/null
+
+# start daemons if configured
+if [ -f /opt/amnezia/awg/wg0.conf ]; then wg-quick up /opt/amnezia/awg/wg0.conf; fi
+
+# Allow traffic on the TUN interface
+IFACE=$(basename /opt/amnezia/awg/wg0.conf .conf)
+iptables -A INPUT -i $IFACE -j ACCEPT
+iptables -A FORWARD -i $IFACE -j ACCEPT
+iptables -A OUTPUT -o $IFACE -j ACCEPT
+
+# Allow forwarding traffic only from the VPN
+iptables -A FORWARD -i $IFACE -o eth0 -s $SUBNET -j ACCEPT
+iptables -A FORWARD -i $IFACE -o eth1 -s $SUBNET -j ACCEPT
+
+iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s $SUBNET -o eth1 -j MASQUERADE
+
+# IPv6 forwarding + NAT66, only when the tunnel has an IPv6 subnet
+if [ -n "$SUBNET6" ] && command -v ip6tables >/dev/null 2>&1; then
+  sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+  ip6tables -A INPUT -i $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -j ACCEPT
+  ip6tables -A OUTPUT -o $IFACE -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth0 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -i $IFACE -o eth1 -s $SUBNET6 -j ACCEPT
+  ip6tables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth0 -j MASQUERADE
+  ip6tables -t nat -A POSTROUTING -s $SUBNET6 -o eth1 -j MASQUERADE
+fi
+
+# Apply per-peer bandwidth limits (flat file written by the panel)
+if [ -f /opt/amnezia/awg/bwlimits ]; then
+(
+
+BW=/opt/amnezia/awg/bwlimits
+IFACE=$(basename /opt/amnezia/awg/wg0.conf .conf)
+[ -f "$BW" ] || exit 0
+command -v tc >/dev/null 2>&1 || exit 0
+ip link show dev $IFACE >/dev/null 2>&1 || exit 0
+tc qdisc del dev $IFACE root 2>/dev/null
+tc qdisc del dev $IFACE ingress 2>/dev/null
+tc qdisc add dev $IFACE root handle 1: htb default 0 2>/dev/null || exit 0
+tc qdisc add dev $IFACE handle ffff: ingress 2>/dev/null || true
+i=0
+while read -r ip4 ip6 mbps; do
+  [ -z "$ip4" ] && continue
+  [ -z "$mbps" ] && continue
+  kbit=$(echo "$mbps" | awk '{printf "%d", $1*1000}')
+  [ "$kbit" -gt 0 ] 2>/dev/null || continue
+  i=$((i+1))
+  cid=$((100+i))
+  tc class add dev $IFACE parent 1: classid 1:$cid htb rate ${kbit}kbit ceil ${kbit}kbit 2>/dev/null
+  tc filter add dev $IFACE parent 1: protocol ip u32 match ip dst $ip4/32 flowid 1:$cid 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent 1: protocol ipv6 u32 match ip6 dst $ip6/128 flowid 1:$cid 2>/dev/null
+  tc filter add dev $IFACE parent ffff: protocol ip u32 match ip src $ip4/32 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+  [ "$ip6" != "-" ] && [ -n "$ip6" ] && tc filter add dev $IFACE parent ffff: protocol ipv6 u32 match ip6 src $ip6/128 police rate ${kbit}kbit burst 64k drop 2>/dev/null
+done < "$BW"
+
+)
+fi
+
+tail -f /dev/null

--- a/tests/test_awg_start_script.py
+++ b/tests/test_awg_start_script.py
@@ -1,0 +1,152 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from managers.awg_manager import (
+    AWG3_USERSPACE_GUARD,
+    AWG_QUICK_FORCE_USERSPACE_PATCH,
+    AWGManager,
+)
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+def fixture(name):
+    with open(os.path.join(FIXTURES, name), encoding='utf-8') as f:
+        return f.read()
+
+
+class RecordingSSH:
+    def __init__(self):
+        self.uploads = {}
+        self.commands = []
+
+    def upload_file(self, content, remote_path):
+        self.uploads[remote_path] = content
+
+    def run_command(self, command, timeout=60):
+        self.commands.append(command)
+        return '', '', 0
+
+    def run_sudo_command(self, command, timeout=60):
+        self.commands.append(command)
+        if 'for p in ' in command:  # _resolve_config_path probe
+            return self.resolved_config_path + '\n', '', 0
+        return '', '', 0
+
+    resolved_config_path = ''
+
+
+class GoldenBuilderTests(unittest.TestCase):
+    """The fixtures were captured from the pre-refactor code by running
+    install_protocol()/save_server_config() against a fake SSH, so equality
+    proves the builders reproduce the previous output byte for byte."""
+
+    def test_start_script_awg(self):
+        self.assertEqual(AWGManager(None)._render_start_script('awg'), fixture('start_awg.sh'))
+
+    def test_start_script_awg3_carries_userspace_guard(self):
+        script = AWGManager(None)._render_start_script('awg3')
+        self.assertEqual(script, fixture('start_awg3.sh'))
+        self.assertIn(AWG3_USERSPACE_GUARD, script)
+
+    def test_start_script_legacy_uses_wg_quick(self):
+        script = AWGManager(None)._render_start_script('awg_legacy')
+        self.assertEqual(script, fixture('start_awg_legacy.sh'))
+        self.assertIn('wg-quick up /opt/amnezia/awg/wg0.conf', script)
+        self.assertNotIn('awg-quick', script)
+
+    def test_start_script_config_path_override(self):
+        script = AWGManager(None)._render_start_script('awg_legacy', config_path='/opt/amnezia/awg/awg0.conf')
+        self.assertIn('wg-quick up /opt/amnezia/awg/awg0.conf', script)
+        self.assertNotIn('/opt/amnezia/awg/wg0.conf', script)
+
+    def test_dockerfile_awg(self):
+        content = AWGManager._dockerfile_content('amneziavpn/amneziawg-go:latest', AWG_QUICK_FORCE_USERSPACE_PATCH)
+        self.assertEqual(content, fixture('dockerfile_awg.txt'))
+
+    def test_dockerfile_legacy_has_no_userspace_patch(self):
+        content = AWGManager._dockerfile_content('amneziavpn/amnezia-wg:latest', '')
+        self.assertEqual(content, fixture('dockerfile_awg_legacy.txt'))
+        self.assertNotIn('WG_FORCE_USERSPACE', content)
+
+    def test_docker_run_drops_the_duplicated_name_flag(self):
+        # The only intentional difference from the old output: `--name` was
+        # emitted twice, the fixture keeps the old form.
+        old = fixture('docker_run_awg.txt')
+        self.assertEqual(old.count('--name amnezia-awg'), 2)
+        expected = old.replace('--name amnezia-awg amnezia-awg', 'amnezia-awg')
+
+        new = AWGManager._docker_run_cmd('amnezia-awg', 'amnezia-awg', '55424', False)
+
+        self.assertEqual(new, expected)
+        self.assertEqual(new.count('--name'), 1)
+
+    def test_docker_run_ipv6_sysctls_only_when_enabled(self):
+        old = fixture('docker_run_awg_ipv6.txt')
+        expected = old.replace('--name amnezia-awg amnezia-awg', 'amnezia-awg')
+
+        new = AWGManager._docker_run_cmd('amnezia-awg', 'amnezia-awg', '55424', True)
+
+        self.assertEqual(new, expected)
+        self.assertIn('net.ipv6.conf.all.disable_ipv6=0', new)
+        self.assertNotIn('disable_ipv6', AWGManager._docker_run_cmd('amnezia-awg', 'amnezia-awg', '55424', False))
+
+    @unittest.skipUnless(shutil.which('bash'), 'bash not available')
+    def test_start_scripts_parse_as_bash(self):
+        for proto in ('awg', 'awg3', 'awg_legacy'):
+            with tempfile.NamedTemporaryFile('w', suffix='.sh', delete=False) as f:
+                f.write(AWGManager(None)._render_start_script(proto))
+            try:
+                result = subprocess.run(['bash', '-n', f.name], capture_output=True, text=True)
+            finally:
+                os.unlink(f.name)
+            self.assertEqual(result.returncode, 0, f'{proto}: {result.stderr}')
+
+
+class StartScriptDeliveryTests(unittest.TestCase):
+    def test_write_start_script_copies_and_marks_executable_without_restart(self):
+        ssh = RecordingSSH()
+        manager = AWGManager(ssh)
+
+        manager._write_start_script('awg2')
+
+        self.assertEqual(ssh.uploads['/tmp/_amnz_start.sh'], manager._render_start_script('awg2'))
+        self.assertEqual(ssh.commands, [
+            'docker cp /tmp/_amnz_start.sh amnezia-awg2:/opt/amnezia/start.sh',
+            'docker exec amnezia-awg2 chmod +x /opt/amnezia/start.sh',
+            'rm -f /tmp/_amnz_start.sh',
+        ])
+
+    def test_upload_start_script_restarts_the_container(self):
+        ssh = RecordingSSH()
+        manager = AWGManager(ssh)
+        import managers.awg_manager as awg_module
+        real_sleep = awg_module.time.sleep
+        awg_module.time.sleep = lambda seconds: None
+        try:
+            manager._upload_start_script('awg2')
+        finally:
+            awg_module.time.sleep = real_sleep
+
+        self.assertEqual(ssh.commands[-1], 'docker restart amnezia-awg2')
+
+    def test_save_server_config_regenerates_start_script_for_resolved_path(self):
+        ssh = RecordingSSH()
+        manager = AWGManager(ssh)
+        # Legacy container whose config actually lives at awg0.conf: the probe
+        # resolves it and the start script must follow the resolved path.
+        ssh.resolved_config_path = '/opt/amnezia/awg/awg0.conf'
+
+        manager.save_server_config('awg_legacy', '[Interface]\nAddress = 10.8.1.1/24\n')
+
+        script = ssh.uploads['/tmp/_amnz_start.sh']
+        self.assertEqual(script, manager._render_start_script('awg_legacy', '/opt/amnezia/awg/awg0.conf'))
+        self.assertIn('docker cp /tmp/_amnz_edit_config.conf amnezia-awg-legacy:/opt/amnezia/awg/awg0.conf', ssh.commands)
+        self.assertEqual(ssh.commands[-1], 'docker restart amnezia-awg-legacy')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

The start script of an AWG container is spelled out twice, byte for byte: in `_upload_start_script()` (install) and inline in `save_server_config()` (raw config editor). Any change to forwarding, NAT, the userspace guard or the bandwidth-limit block has to be made in both places, and nothing checks that the two copies stay identical. The Dockerfile and the `docker run` line are likewise inline f-strings inside the 200-line `install_protocol()`, which makes them impossible to unit-test and awkward to reuse.

## The fix

Pure builders on `AWGManager`, no SSH inside:

- `_dockerfile_content(docker_image, userspace_patch)`
- `_docker_run_cmd(container_name, image, port, ipv6_enabled)`
- `_start_script_body(config_path, quick_bin, userspace_guard, subnet_default, bwlimits_path)`

plus `_render_start_script(protocol_type, config_path=None)` (instance wrapper) and `_write_start_script(protocol_type, config_path=None)` (upload + `docker cp` + `chmod +x`, **no restart**). `_upload_start_script(protocol_type)` is now "write + `docker restart` + sleep" and loses the `port`/`awg_params` parameters it never used (single caller updated). `save_server_config()` calls `_write_start_script()` with the resolved config path, exactly as before, then restarts.

**One intentional difference:** `docker run` emitted `--name <container>` twice; it is emitted once now. Everything else is byte-identical — see below. `WireGuardManager` (an independent copy) is untouched. Single commit on top of `main`, independent of #119/#121/#122.

Net: +116 / −145 in `managers/awg_manager.py`.

## Testing

`tests/fixtures/` holds the Dockerfile (awg, awg_legacy), `docker run` line (IPv4-only and dual-stack) and `start.sh` (awg, awg3, awg_legacy) **captured from the pre-refactor code** by running `install_protocol()` / `save_server_config()` on `main` against a fake SSH (that run also confirmed the two old start-script copies were identical). `tests/test_awg_start_script.py` (12 cases) asserts the new builders reproduce those fixtures exactly, that the run line equals the old one minus the duplicated `--name`, that the IPv6 sysctls appear only when enabled, that the rendered scripts pass `bash -n`, and that `_write_start_script` / `_upload_start_script` / `save_server_config` issue the same SSH sequence as before (`docker cp` → `chmod +x` → `rm`, restart only where it was).

`python -m unittest discover -s tests` → 93 tests OK (fork CI: https://github.com/helldweller/Amnezia-Web-Panel/actions/runs/33789001103). Exercised on a real server as well: a fresh `awg2` instance installed through the new path and the raw-config save on an existing one — start.sh/Dockerfile inside the containers match the fixtures, `awg show` is up after the restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)