### PR TITLE
fix(xray): set bbr instead of hybla in container sysctl tuning

### DIFF
--- a/managers/xray_manager.py
+++ b/managers/xray_manager.py
@@ -202,7 +202,7 @@ RUN echo "fs.file-max = 51200" >> /etc/sysctl.conf && \\
     echo "net.ipv4.tcp_rmem = 4096 87380 67108864" >> /etc/sysctl.conf && \\
     echo "net.ipv4.tcp_wmem = 4096 65536 67108864" >> /etc/sysctl.conf && \\
     echo "net.ipv4.tcp_mtu_probing = 1" >> /etc/sysctl.conf && \\
-    echo "net.ipv4.tcp_congestion_control = hybla" >> /etc/sysctl.conf
+    echo "net.ipv4.tcp_congestion_control = bbr" >> /etc/sysctl.conf
 
 RUN mkdir -p /etc/security && \\
     echo "* soft nofile 51200" >> /etc/security/limits.conf && \\


### PR DESCRIPTION
## Problem
The xray image Dockerfile writes `net.ipv4.tcp_congestion_control = hybla` into `/etc/sysctl.conf` inside the image (`managers/xray_manager.py`). The container runs `--privileged` and its `start.sh` runs `sysctl -p /etc/sysctl.conf`, so **every container (re)start pushes hybla onto the HOST**, silently overriding the bbr configured by `setup_host_tuning()` and sysctl.d.

Reproduction: on a host with an xray instance, `sysctl net.ipv4.tcp_congestion_control` flips to `hybla` after container restarts (visible in journalctl as `sudo sysctl net.ipv4.tcp_congestion_control=hybla`).

## Fix
One line: hybla -> bbr, consistent with the rest of the panel (awg_manager host tuning).

## Note for later (not in this PR)
The same Dockerfile pushes ~15 more sysctls onto the host through the privileged container (rmem/wmem 64M, tcp_tw_reuse, etc.). Consider moving that tuning to the host level like awg_manager does.