### PR TITLE
fix(telegram): allow admins to create connection in telegram

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1320,7 +1320,7 @@ async def _handle_pending_input(api: TelegramAPI, msg: dict, load_data_fn: Calla
 
     if state.get("kind") == "user_add_client_name":
         panel_user = _find_user(load_data_fn, str(msg["from"]["id"]), msg["from"].get("username"))
-        if not panel_user or _is_admin(panel_user):
+        if not panel_user:
             _pending_inputs.pop(key, None)
             await api.send_message(chat_id, f"❌ {_tt(lang, 'access_denied')}")
             return True

--- a/tests/test_telegram_self_service.py
+++ b/tests/test_telegram_self_service.py
@@ -358,6 +358,25 @@ class TestUserAddClientNameInputState(unittest.IsolatedAsyncioTestCase):
         call_args = self.mock_service.create_user_connection.call_args
         self.assertEqual(call_args[0][0], 'user-1')
 
+    async def test_input_state_creates_connection_for_admin(self):
+        tg_bot._pending_inputs['222:222'] = {
+            'kind': 'user_add_client_name',
+            'sid': 0,
+            'proto': 'awg',
+            'ts': 0,
+        }
+        msg = {'chat': {'id': 222}, 'from': {'id': 222, 'first_name': 'Admin'}, 'text': 'AdminPhone'}
+
+        handled = await tg_bot._handle_pending_input(
+            self.api, msg, self.load_data, None, lambda c: 'vpn://x', self.mock_service
+        )
+
+        self.assertTrue(handled)
+        self.mock_service.create_user_connection.assert_called_once()
+        call_args = self.mock_service.create_user_connection.call_args
+        self.assertEqual(call_args[0][0], 'user-2')
+        self.assertEqual(call_args[0][3], 'AdminPhone')
+
     async def test_input_state_rejects_unlinked_user(self):
         tg_bot._pending_inputs['999:999'] = {
             'kind': 'user_add_client_name',


### PR DESCRIPTION
### Problem.
After an admin typed a client name, _handle_pending_input for user_add_client_name rejected them with “access denied” because it treated _is_admin(panel_user) as a hard stop. Regular users could complete the same wizard; admins could not.

### Change.
Keep the unlinked-user check (if not panel_user) and drop the admin exclusion so a linked admin is resolved and create_user_connection runs for them, same as for a regular user.
