### PR TITLE
fix(ssh): serialize command/SFTP execution on pooled connections

### DIFF
--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -26,6 +26,14 @@ class SSHManager:
         # Serializes connect/disconnect so concurrent threads (UI request
         # handler + background monitor) cannot race a half-built transport.
         self._conn_lock = threading.Lock()
+        # Serializes command/SFTP execution on the shared transport. Pooled
+        # managers are used concurrently by request handlers and background
+        # threads (traffic sync, conn monitor); without this a failed
+        # exec on one side triggers a reconnect that closes the client the
+        # other side is mid-command on ('NoneType open_session', EOFError
+        # in open_sftp, bursts of 500s followed by the connect cooldown).
+        # RLock because run_command retries by calling itself.
+        self._exec_lock = threading.RLock()
         # Backoff: after a failed connect, do not hammer the dead server on
         # every request (each attempt costs up to `timeout` seconds and can
         # exhaust the web worker pool when several servers are down).
@@ -152,6 +160,10 @@ class SSHManager:
 
     def run_command(self, command, timeout=60, _retried=False):
         """Execute command on remote server."""
+        with self._exec_lock:
+            return self._run_command_locked(command, timeout, _retried)
+
+    def _run_command_locked(self, command, timeout, _retried):
         self.ensure_connected()
 
         logger.info(f"Running command: {command[:100]}...")
@@ -251,6 +263,10 @@ class SSHManager:
 
     def upload_file(self, content, remote_path):
         """Upload text content to a remote file via SFTP."""
+        with self._exec_lock:
+            return self._upload_file_locked(content, remote_path)
+
+    def _upload_file_locked(self, content, remote_path):
         self.ensure_connected()
 
         # Normalize line endings (Windows CRLF -> Unix LF)
@@ -286,6 +302,10 @@ class SSHManager:
 
     def download_file(self, remote_path):
         """Download text content from a remote file."""
+        with self._exec_lock:
+            return self._download_file_locked(remote_path)
+
+    def _download_file_locked(self, remote_path):
         self.ensure_connected()
 
         sftp = self.client.open_sftp()
@@ -297,6 +317,10 @@ class SSHManager:
 
     def file_exists(self, remote_path):
         """Check if a remote file exists."""
+        with self._exec_lock:
+            return self._file_exists_locked(remote_path)
+
+    def _file_exists_locked(self, remote_path):
         self.ensure_connected()
 
         sftp = self.client.open_sftp()


### PR DESCRIPTION
Fixes #125.

## Problem
The pooled `SSHManager` (one per server) is shared between request handlers and background threads (traffic sync, connection monitor). When one side's `exec_command` failed, its reconnect path closed the shared client while the other side was mid-command: `NoneType open_session`, `EOFError` in `open_sftp`, a burst of 500s, then 30 s of fast-fail from the connect cooldown.

## Fix
An `RLock` around `exec_command` and all SFTP operations:
- command execution and reconnects are serialized per connection - a failed exec now waits, reconnects, and retries without yanking the transport from other threads;
- `RLock` (not `Lock`) because `run_command` retries by re-entering itself;
- lock ordering is exec -> conn (`connect`/`disconnect` never take the exec lock), so no deadlock.

Smoke-tested with 10 threads concurrently hammering `run_command` against a dead host: all serialize and fail cleanly, no race artifacts.

Kept it to one connection per server (no separate manager for background loops) to avoid doubling SSH sessions on managed hosts.