### PR TITLE
fix(awg): report the actual reason when kernel module setup fails

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -724,45 +724,66 @@ fi
         """
         v = self.AWG_MODULE_VERSION
         script = f"""
-set -e
 if modinfo amneziawg >/dev/null 2>&1; then
-    echo "KERNEL_MODULE: already present ($(modinfo amneziawg | awk '/^version:/{{print $2; exit}}'))"
+    echo "KERNEL_MODULE: ok: already present ($(modinfo amneziawg | awk '/^version:/{{print $2; exit}}'))"
     exit 0
 fi
 if command -v mokutil >/dev/null 2>&1 && mokutil --sb-state 2>/dev/null | grep -qi 'enabled'; then
-    echo "KERNEL_MODULE: skipped (Secure Boot enabled)"
+    echo "KERNEL_MODULE: skipped: Secure Boot enabled (unsigned module would not load)"
     exit 0
 fi
+KVER=$(uname -r)
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq dkms "linux-headers-$(uname -r)" git make gcc
+if ! apt-get install -y -qq dkms "linux-headers-$KVER" git make gcc >/tmp/awg-kmod.log 2>&1; then
+    if ! apt-cache show "linux-headers-$KVER" >/dev/null 2>&1; then
+        echo "KERNEL_MODULE: failed: headers for the running kernel $KVER are no longer in the repos - upgrade the kernel (apt install linux-image-amd64) and reboot, then reinstall the protocol"
+    else
+        echo "KERNEL_MODULE: failed: cannot install build tools: $(tail -3 /tmp/awg-kmod.log | tr '\\n' ' ' | cut -c1-300)"
+    fi
+    exit 1
+fi
 rm -rf /tmp/awg-module
-git clone --depth 1 --branch v{v} {self.AWG_MODULE_REPO} /tmp/awg-module
+if ! git clone --depth 1 --branch v{v} {self.AWG_MODULE_REPO} /tmp/awg-module >>/tmp/awg-kmod.log 2>&1; then
+    echo "KERNEL_MODULE: failed: cannot clone the module repo (github.com unreachable?)"
+    exit 1
+fi
 cd /tmp/awg-module/src
 sed -i 's/^PACKAGE_VERSION=.*/PACKAGE_VERSION="{v}"/' dkms.conf
-dkms add .
-dkms build amneziawg/{v}
-dkms install amneziawg/{v}
-modprobe amneziawg
+if ! dkms add . >>/tmp/awg-kmod.log 2>&1; then
+    echo "KERNEL_MODULE: failed: dkms add failed: $(tail -3 /tmp/awg-kmod.log | tr '\\n' ' ' | cut -c1-300)"
+    exit 1
+fi
+if ! dkms build amneziawg/{v} >>/tmp/awg-kmod.log 2>&1; then
+    REASON=$(tail -5 /var/lib/dkms/amneziawg/{v}/build/make.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)
+    echo "KERNEL_MODULE: failed: dkms build failed: ${{REASON:-see /var/lib/dkms/amneziawg/{v}/build/make.log}}"
+    exit 1
+fi
+if ! dkms install amneziawg/{v} >>/tmp/awg-kmod.log 2>&1; then
+    echo "KERNEL_MODULE: failed: dkms install failed: $(tail -3 /tmp/awg-kmod.log | tr '\\n' ' ' | cut -c1-300)"
+    exit 1
+fi
+if ! modprobe amneziawg 2>/tmp/awg-kmod.log; then
+    echo "KERNEL_MODULE: failed: module built but modprobe failed: $(tail -2 /tmp/awg-kmod.log | tr '\\n' ' ' | cut -c1-200)"
+    exit 1
+fi
 cd / && rm -rf /tmp/awg-module
-echo "KERNEL_MODULE: installed {v}"
+echo "KERNEL_MODULE: ok: installed {v}"
 """
         try:
             out, err, code = self.ssh.run_sudo_script(script, timeout=600)
             marker = ''
             for line in (out or '').splitlines():
                 if line.startswith('KERNEL_MODULE:'):
-                    marker = line
+                    marker = line.split(':', 1)[1].strip()
                     logger.info(f"setup_kernel_module: {line}")
-            if code != 0:
-                logger.warning(f"setup_kernel_module failed, userspace fallback: {err}")
-                return 'failed'
-            if 'installed' in marker or 'already present' in marker:
-                return 'ok'
-            return 'skipped'
+            if not marker:
+                logger.warning(f"setup_kernel_module: no marker, userspace fallback: {err}")
+                return 'failed: no result (SSH or script error)'
+            return marker
         except Exception as err:
             logger.warning(f"setup_kernel_module warning (userspace fallback): {err}")
-            return 'failed'
+            return f'failed: {err}'
 
     def setup_firewall(self):
         """Setup host firewall (mirrors setup_host_firewall.sh).
@@ -922,12 +943,13 @@ done
         # Step 2.5: Kernel module (best effort, userspace fallback)
         results.append("Checking amneziawg kernel module...")
         km = self.setup_kernel_module()
-        if km == 'ok':
-            results.append("Kernel module ready")
-        elif km == 'skipped':
-            results.append("Kernel module skipped, userspace mode (amneziawg-go)")
+        if km.startswith('ok'):
+            detail = km.split(':', 1)[1].strip() if ':' in km else ''
+            results.append(f"Kernel module ready ({detail})" if detail else "Kernel module ready")
+        elif km.startswith('skipped'):
+            results.append(f"Kernel module skipped, userspace mode (amneziawg-go): {km.split(':', 1)[-1].strip()}")
         else:
-            results.append("Kernel module build failed, userspace mode (amneziawg-go)")
+            results.append(f"Kernel module failed, userspace mode (amneziawg-go): {km.split(':', 1)[-1].strip()}")
 
         # Step 3: Remove old container if exists
         if self.check_protocol_installed(protocol_type):


### PR DESCRIPTION
## Problem

When the amneziawg kernel module cannot be set up during AWG/AWG2/AWG3 installation, the install log only says:

```
Kernel module build failed, userspace mode (amneziawg-go)
```

The DKMS script uses `set -e`, so the first failing command aborts it and the real cause (missing kernel headers, Secure Boot, unreachable GitHub, modprobe failure, ...) never reaches the user. I hit this on a Debian 12 host running kernel 6.1.0-9: headers for that exact kernel are no longer in the repos, so the module can never build until the kernel is upgraded — but the panel gave no hint of that.

## Fix

The setup script now checks each step explicitly and emits a specific reason:

- `headers for the running kernel X are no longer in the repos - upgrade the kernel (apt install linux-image-amd64) and reboot, then reinstall the protocol`
- `Secure Boot enabled (unsigned module would not load)`
- `cannot install build tools: <apt output tail>`
- `cannot clone the module repo (github.com unreachable?)`
- `dkms build failed: <make.log tail>`
- `module built but modprobe failed: <error>`

The reason is appended to the install log line, e.g.:

```
Kernel module failed, userspace mode (amneziawg-go): headers for the running kernel 6.1.0-9-amd64 are no longer in the repos - upgrade the kernel and reboot
```

Behavior is unchanged (still best-effort with userspace fallback) — only the diagnostics improve.