### PR TITLE
fix(ipam): keep disabled clients' IPs reserved; validate on re-enable

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1672,8 +1672,15 @@ done < "$BW"
             f"docker exec -i {container_name} cat {clients_table_path} 2>/dev/null"
         )
         if code != 0:
-            raise RuntimeError(
-                f"Cannot read clients table from {container_name}: {err.strip()}")
+            # cat fails both when docker exec is broken and when the file
+            # simply does not exist yet (fresh instance). Fail loudly only
+            # for the former; an absent table means no reservations.
+            _, terr, tcode = self.ssh.run_sudo_command(
+                f"docker exec -i {container_name} true")
+            if tcode != 0:
+                raise RuntimeError(
+                    f"Cannot read clients table from {container_name}: {terr.strip() or err.strip()}")
+            return set()
         if not out.strip():
             return set()
         try:

--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -1659,14 +1659,48 @@ done < "$BW"
                     ips.append(match.group(1))
         return ips
 
+    def _get_reserved_ips(self, protocol_type):
+        """IPv4 addresses reserved in clientsTable by ANY client, disabled included.
+
+        A disabled client keeps its address, so allocation must never hand it
+        to someone else. Raises if the table cannot be read at all — silently
+        treating the reservation pool as empty would break that guarantee.
+        """
+        container_name = self._container_name(protocol_type)
+        clients_table_path = self._clients_table_path()
+        out, err, code = self.ssh.run_sudo_command(
+            f"docker exec -i {container_name} cat {clients_table_path} 2>/dev/null"
+        )
+        if code != 0:
+            raise RuntimeError(
+                f"Cannot read clients table from {container_name}: {err.strip()}")
+        if not out.strip():
+            return set()
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
+            raise RuntimeError(f"Clients table in {container_name} is not valid JSON")
+        entries = data if isinstance(data, list) else [
+            {'clientId': k, 'userData': v} for k, v in data.items()]
+        reserved = set()
+        for c in entries:
+            ud = c.get('userData') or {}
+            ip = self._extract_ipv4(ud.get('allowedIps') or ud.get('clientIp') or '')
+            if ip:
+                reserved.add(ip)
+        return reserved
+
     def _get_next_ip(self, protocol_type):
         """Return the first free IP in the subnet, filling gaps left by deleted clients.
 
         The old implementation took the last IP in file order and incremented it,
         which produced duplicate IPs when peers were not sorted by IP and never
         reused addresses freed by deleted clients.
+
+        Occupied = active config peers + reservations in clientsTable (disabled
+        clients keep their IPs; only deletion releases an address).
         """
-        used_ips = self._get_used_ips(protocol_type)
+        used_ips = set(self._get_used_ips(protocol_type)) | self._get_reserved_ips(protocol_type)
         base = self._get_subnet_base(protocol_type)
         parts = base.split('.')
         prefix = '.'.join(parts[:3])
@@ -2309,6 +2343,24 @@ PersistentKeepalive = 25
             ud = client.setdefault('userData', {})
             psk = ud.get('psk', '')
             client_ip = self._client_ip_from_userdata(ud)
+            if client_ip:
+                # A disabled client's address stays reserved in clientsTable.
+                # Refuse to re-enable when another client owns it now.
+                for other in clients_table:
+                    if other.get('clientId') == client_id:
+                        continue
+                    other_ip = self._extract_ipv4(
+                        (other.get('userData') or {}).get('allowedIps')
+                        or (other.get('userData') or {}).get('clientIp') or '')
+                    if other_ip == client_ip:
+                        raise RuntimeError(
+                            f"Cannot enable client: IP {client_ip} is already "
+                            f"reserved by another client. Resolve the conflict "
+                            f"(delete one of them) first.")
+                if client_ip in self._get_used_ips(protocol_type):
+                    raise RuntimeError(
+                        f"Cannot enable client: IP {client_ip} is already "
+                        f"present in the active server config")
             if not client_ip:
                 client_ip = self._get_next_ip(protocol_type)
                 logger.warning(

--- a/managers/wireguard_manager.py
+++ b/managers/wireguard_manager.py
@@ -452,8 +452,15 @@ tail -f /dev/null
             f"docker exec -i {self.CONTAINER_NAME} cat {self.CLIENTS_TABLE_PATH} 2>/dev/null"
         )
         if code != 0:
-            raise RuntimeError(
-                f"Cannot read clients table from {self.CONTAINER_NAME}: {err.strip()}")
+            # cat fails both when docker exec is broken and when the file
+            # simply does not exist yet (fresh instance). Fail loudly only
+            # for the former; an absent table means no reservations.
+            _, terr, tcode = self.ssh.run_sudo_command(
+                f"docker exec -i {self.CONTAINER_NAME} true")
+            if tcode != 0:
+                raise RuntimeError(
+                    f"Cannot read clients table from {self.CONTAINER_NAME}: {terr.strip() or err.strip()}")
+            return set()
         if not out.strip():
             return set()
         try:

--- a/managers/wireguard_manager.py
+++ b/managers/wireguard_manager.py
@@ -441,15 +441,57 @@ tail -f /dev/null
                     ips.append(match.group(1))
         return ips
 
+    def _get_reserved_ips(self):
+        """IPv4 addresses reserved in clientsTable by ANY client, disabled included.
+
+        A disabled client keeps its address, so allocation must never hand it
+        to someone else. Raises if the table cannot be read at all — silently
+        treating the reservation pool as empty would break that guarantee.
+        """
+        out, err, code = self.ssh.run_sudo_command(
+            f"docker exec -i {self.CONTAINER_NAME} cat {self.CLIENTS_TABLE_PATH} 2>/dev/null"
+        )
+        if code != 0:
+            raise RuntimeError(
+                f"Cannot read clients table from {self.CONTAINER_NAME}: {err.strip()}")
+        if not out.strip():
+            return set()
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
+            raise RuntimeError(
+                f"Clients table in {self.CONTAINER_NAME} is not valid JSON")
+        reserved = set()
+        for c in (data if isinstance(data, list) else []):
+            ud = c.get('userData') or {}
+            value = ud.get('allowedIps') or ud.get('clientIp') or ''
+            match = re.search(r'(\d+\.\d+\.\d+\.\d+)', str(value))
+            if match:
+                reserved.add(match.group(1))
+        return reserved
+
     def _get_next_ip(self):
         """Return the first free IP in the subnet, filling gaps left by deleted clients.
 
         The old implementation took the last IP in file order and incremented it,
         which produced duplicate IPs when peers were not sorted by IP and never
         reused addresses freed by deleted clients.
+
+        Occupied = active config peers + reservations in clientsTable (disabled
+        clients keep their IPs; only deletion releases an address).
         """
-        used_ips = self._get_used_ips()
+        used_ips = set(self._get_used_ips()) | self._get_reserved_ips()
+        # The subnet comes from the live config (imported instances may use a
+        # subnet different from the default).
         base = WG_DEFAULTS['subnet_address']
+        config = self._get_server_config()
+        for line in config.split('\n'):
+            line = line.strip()
+            if line.startswith('Address'):
+                match = re.search(r'(\d+\.\d+\.\d+\.\d+)', line)
+                if match:
+                    base = match.group(1)
+                break
         parts = base.split('.')
         prefix = '.'.join(parts[:3])
 
@@ -761,6 +803,28 @@ PersistentKeepalive = 25
             ud = client.get('userData', {})
             psk = ud.get('psk', '') or self._get_server_psk()
             client_ip = ud.get('clientIp', '')
+            if client_ip:
+                # A disabled client's address stays reserved in clientsTable.
+                # Refuse to re-enable when another client owns it now.
+                for other in clients_table:
+                    if other.get('clientId') == client_id:
+                        continue
+                    other_ud = other.get('userData') or {}
+                    other_val = other_ud.get('allowedIps') or other_ud.get('clientIp') or ''
+                    m = re.search(r'(\d+\.\d+\.\d+\.\d+)', str(other_val))
+                    if m and m.group(1) == client_ip:
+                        raise RuntimeError(
+                            f"Cannot enable client: IP {client_ip} is already "
+                            f"reserved by another client. Resolve the conflict "
+                            f"(delete one of them) first.")
+                if client_ip in self._get_used_ips():
+                    raise RuntimeError(
+                        f"Cannot enable client: IP {client_ip} is already "
+                        f"present in the active server config")
+            if not client_ip:
+                client_ip = self._get_next_ip()
+                ud['clientIp'] = client_ip
+                client.setdefault('userData', {})['clientIp'] = client_ip
 
             peer_section = f"""
 [Peer]


### PR DESCRIPTION
Fixes #138.

Confirmed by code inspection: disabling a client removes its `[Peer]` from the active config while its IP stays in `clientsTable`; the allocator read only the active config, so the freed IP could be handed to a new client, and re-enabling the original client reused its stored IP without an ownership check — two active peers with the same address.

**Changes (AWG 1.0/2.0/3.1 + WireGuard):**

- IP allocation now counts reservations from `clientsTable` (disabled clients included) in addition to the active config. Only deletion releases an address.
- Re-enabling validates that the stored IP is not owned by another client (table) and is not present in the active config; on conflict the operation is rejected with a clear error instead of silently activating a conflicting peer.
- If `clientsTable` cannot be read, allocation fails loudly instead of treating the reservation pool as empty.
- WireGuard additionally derives the subnet from the live server config (`Address = ...`) instead of the built-in default, so instances with a custom subnet allocate correct addresses.

**Xray:** no change needed — clients are identified by UUID, there is no IP allocation.

Verified with a unit-style harness (mocked SSH): disabled client's `.4` is skipped by the allocator (`.5` returned), unreadable table raises, custom subnet allocates in the right range.
