### PR TITLE
fix(tests): skip the Playwright e2e module when pytest is missing

### DIFF
--- a/tests/test_playwright_e2e.py
+++ b/tests/test_playwright_e2e.py
@@ -1,6 +1,17 @@
-"""Playwright E2E tests for Amnezia Web Panel."""
-import pytest
-from playwright.sync_api import Page, expect
+"""Playwright E2E tests for Amnezia Web Panel.
+
+Run with pytest against a panel already serving on BASE_URL. `unittest
+discover` imports every tests/ module, and pytest is not in requirements.txt,
+so the import is guarded: without it the module skips instead of failing the
+whole suite.
+"""
+import unittest
+
+try:
+    import pytest
+    from playwright.sync_api import Page, expect
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    raise unittest.SkipTest(f"Playwright e2e tests need pytest: {exc}")
 
 BASE_URL = "http://127.0.0.1:8000"
 


### PR DESCRIPTION
## The problem

`tests/test_playwright_e2e.py` opens with a bare `import pytest`, but `pytest` is not in `requirements.txt` — only `playwright` is. CI installs `requirements.txt` and runs `python -m unittest discover -s tests`, which imports every module under `tests/`, so collection aborts on that import and takes the whole suite down with it.

`main` has been red since the module landed. The Tests workflow reports `FAILED (errors=1)` with `ModuleNotFoundError: No module named 'pytest'` on the #134 merge, on the v1.6.4 tag and on the follow-up commit — and none of the 152 real unit tests get reported at all, so any actual regression would now be invisible.

## The fix

Guard the import and raise `unittest.SkipTest`, so `unittest discover` skips this one module and keeps running the rest.

Nothing changes for pytest users: with pytest installed the import succeeds and `pytest tests/test_playwright_e2e.py` behaves exactly as before. The docstring now also records that the module expects a panel already serving on `BASE_URL`, which is easy to miss.

The alternative — adding `pytest` to `requirements.txt` — pulls a test runner into the panel's runtime dependencies, and `unittest discover` still would not execute these tests: they are pytest fixtures and plain classes, not `unittest.TestCase`.

## Testing

On this branch, with `requirements.txt` installed and no pytest:

```
before: Ran 152 tests in 0.165s   FAILED (errors=1)
after:  Ran 152 tests in 0.158s   OK (skipped=1)
```