### PR TITLE
fix: run privileged command chains inside one shell

### DIFF
--- a/app.py
+++ b/app.py
@@ -3686,8 +3686,9 @@ async def api_protocol_backup_download(request: Request, server_id: int, req: Ba
         ssh.connect()
         quoted_remote = shlex.quote(remote_path)
         quoted_tmp = shlex.quote(tmp_remote)
+        # `sudo <a> && <b>` elevates only `<a>`; the whole chain needs one shell
         _, err, code = ssh.run_sudo_command(
-            f"test -f {quoted_remote} && cp {quoted_remote} {quoted_tmp} && chmod 0644 {quoted_tmp}"
+            f"sh -c {shlex.quote(f'test -f {quoted_remote} && cp {quoted_remote} {quoted_tmp} && chmod 0644 {quoted_tmp}')}"
         )
         if code != 0:
             return JSONResponse({'error': err or 'Backup not found'}, status_code=404)

--- a/managers/adguard_manager.py
+++ b/managers/adguard_manager.py
@@ -152,9 +152,10 @@ class AdguardManager:
     # ===================== INSTALL / REMOVE =====================
 
     def _ensure_network(self):
+        # Both halves need root: `sudo <ls> || <create>` would create unprivileged
         self.ssh.run_sudo_command(
-            f"docker network ls | grep -q {self.NETWORK_NAME} || "
-            f"docker network create --subnet {self.NETWORK_SUBNET} {self.NETWORK_NAME}"
+            f"sh -c 'docker network ls | grep -q {self.NETWORK_NAME} || "
+            f"docker network create --subnet {self.NETWORK_SUBNET} {self.NETWORK_NAME}'"
         )
 
     def install_protocol(

--- a/managers/backup_manager.py
+++ b/managers/backup_manager.py
@@ -283,8 +283,11 @@ printf '%s\n' "$archive"
         tmp_remote = f'/tmp/_amnz_validate_{safe_name}'
         quoted_remote = shlex.quote(remote_path)
         quoted_tmp = shlex.quote(tmp_remote)
+        # One privileged shell for the whole chain: `sudo <a> && <b>` elevates
+        # only `<a>`, so the copy out of the root-owned backup directory would
+        # fail with "Permission denied" on every non-root server.
         _, err, code = self.ssh.run_sudo_command(
-            f"test -f {quoted_remote} && cp {quoted_remote} {quoted_tmp} && chmod 0644 {quoted_tmp}"
+            f"sh -c {shlex.quote(f'test -f {quoted_remote} && cp {quoted_remote} {quoted_tmp} && chmod 0644 {quoted_tmp}')}"
         )
         if code != 0:
             return None, err or 'Backup not found'

--- a/managers/dns_manager.py
+++ b/managers/dns_manager.py
@@ -42,7 +42,10 @@ COPY forward-records.conf /opt/unbound/etc/unbound/forward-records.conf
             self.ssh.run_sudo_command("docker rm amnezia-dns || true")
             
             # Create internal network for DNS (like original Amnezia client)
-            self.ssh.run_sudo_command("docker network ls | grep -q amnezia-dns-net || docker network create --subnet 172.29.172.0/24 amnezia-dns-net")
+            # Both halves need root: `sudo <a> || <b>` would run the create unprivileged
+            self.ssh.run_sudo_command(
+                "sh -c 'docker network ls | grep -q amnezia-dns-net || "
+                "docker network create --subnet 172.29.172.0/24 amnezia-dns-net'")
             
             # Use internal network with static IP. Do not expose 53 on host to avoid systemd-resolved conflict.
             cmd = "docker run -d --name amnezia-dns --restart always --network amnezia-dns-net --ip=172.29.172.254 amnezia-dns"
@@ -51,7 +54,11 @@ COPY forward-records.conf /opt/unbound/etc/unbound/forward-records.conf
             # Connect existing VPN containers to the DNS network
             vpn_containers = ['amnezia-awg', 'amnezia-awg2', 'amnezia-awg-legacy', 'amnezia-xray', 'telemt']
             for c in vpn_containers:
-                self.ssh.run_sudo_command(f"docker ps | grep -q {c} && docker network connect amnezia-dns-net {c} || true")
+                # `docker network connect` also needs root, so the whole chain
+                # goes to one shell (see _fetch_remote_archive for the same trap)
+                self.ssh.run_sudo_command(
+                    f"sh -c 'docker ps | grep -q {c} && "
+                    f"docker network connect amnezia-dns-net {c} || true'")
 
             return {"status": "success", "message": "AmneziaDNS installed successfully"}
         except Exception as e:

--- a/tests/test_sudo_command_chains.py
+++ b/tests/test_sudo_command_chains.py
@@ -1,0 +1,91 @@
+"""A privileged command chain must run inside one shell.
+
+`SSHManager.run_sudo_command` builds `echo <pw> | sudo -S -p '' <command>`, so
+in `sudo a && b` only `a` is privileged: `b` runs as the panel's unprivileged
+SSH user. Wherever both halves need root, the chain has to be handed to a
+single `sh -c` (the pattern the rest of BackupManager already uses).
+"""
+
+import unittest
+
+from managers.backup_manager import BackupManager
+from managers.adguard_manager import AdguardManager
+from managers.dns_manager import DNSManager
+
+
+class RecordingSSH:
+    def __init__(self, code=1):
+        self.commands = []
+        self.code = code
+
+    def run_sudo_command(self, command, timeout=60):
+        self.commands.append(command)
+        return '', 'not found', self.code
+
+    def run_command(self, command, timeout=60):
+        self.commands.append(command)
+        # DNSManager gates its install on this probe
+        return ('Docker version 27.0.3' if 'docker --version' in command else ''), '', 0
+
+    def write_file(self, path, content):
+        pass
+
+
+def chain_is_wrapped(command):
+    """True when every `&&`/`||`/`|` sits inside a `sh -c`/`bash -c` argument."""
+    for token in ('&&', '||', '|'):
+        idx = command.find(token)
+        if idx == -1:
+            continue
+        shell = min((command.find(s) for s in ('sh -c', 'bash -c') if command.find(s) != -1), default=-1)
+        if shell == -1 or shell > idx:
+            return False
+    return True
+
+
+class SudoChainTests(unittest.TestCase):
+    def test_backup_fetch_runs_the_chain_in_one_shell(self):
+        ssh = RecordingSSH()
+        BackupManager(ssh)._fetch_remote_archive('/opt/amnezia/backups/awg2/awg2-2026.tar.gz')
+        cmd = ssh.commands[0]
+        self.assertTrue(cmd.startswith('sh -c '), cmd)
+        self.assertTrue(chain_is_wrapped(cmd), cmd)
+        # the copy still targets the same paths
+        self.assertIn('/opt/amnezia/backups/awg2/awg2-2026.tar.gz', cmd)
+        self.assertIn('chmod 0644', cmd)
+
+    def test_dns_network_creation_runs_the_chain_in_one_shell(self):
+        ssh = RecordingSSH(code=0)
+        try:
+            DNSManager(ssh).install_protocol()
+        except Exception:
+            pass
+        network = [c for c in ssh.commands if 'amnezia-dns-net' in c and 'network' in c]
+        self.assertTrue(network, ssh.commands)
+        self.assertTrue(chain_is_wrapped(network[0]), network[0])
+
+    def test_dns_attaches_existing_containers_in_one_shell(self):
+        ssh = RecordingSSH(code=0)
+        try:
+            DNSManager(ssh).install_protocol()
+        except Exception:
+            pass
+        connects = [c for c in ssh.commands if 'network connect' in c]
+        self.assertTrue(connects, ssh.commands)
+        for cmd in connects:
+            self.assertTrue(chain_is_wrapped(cmd), cmd)
+        # a representative container is among the ones attached
+        self.assertTrue(any('amnezia-awg2' in c for c in connects), connects)
+
+    def test_adguard_network_creation_runs_the_chain_in_one_shell(self):
+        ssh = RecordingSSH(code=0)
+        AdguardManager(ssh)._ensure_network()
+        self.assertTrue(chain_is_wrapped(ssh.commands[0]), ssh.commands[0])
+
+    def test_helper_flags_a_bare_chain(self):
+        self.assertFalse(chain_is_wrapped("test -f a && cp a b"))
+        self.assertTrue(chain_is_wrapped("sh -c 'test -f a && cp a b'"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

`SSHManager.run_sudo_command("a && b")` builds `echo <pw> | sudo -S -p '' a && b`. Shell precedence means sudo elevates **only the first command** of the chain — everything after `&&` runs as the unprivileged SSH user and fails on anything root-owned.

Four call sites are affected:

- **`managers/backup_manager.py`** — restoring a protocol backup copies the archive out of `/opt/amnezia/backups`, which is root-owned. The restore died with `cp: cannot stat '/opt/amnezia/backups/awg2/awg2-20260907-101500.tar.gz': Permission denied` immediately after reporting it had found the archive. This is how I ran into it.
- **`app.py`** — the inline backup-download chain has the same shape.
- **`managers/dns_manager.py`** — `docker network create` and the per-container attach loop. The attach silently never happened, so containers that existed before AmneziaDNS was installed were left off `amnezia-dns-net` — a failure with no error message anywhere.
- **`managers/adguard_manager.py`** — `_ensure_network()`, same shape.

## The fix

Each chain goes to a single shell via `sh -c '<chain>'` with the arguments quoted, so the whole chain runs under sudo.

`tests/test_sudo_command_chains.py` records what a fake SSH layer receives and asserts every privileged chain in these paths is wrapped, plus a unit check on the detection helper itself. A new bare `&&` in one of these call sites now fails the suite instead of shipping.

## Testing

- `python -m unittest discover -s tests` → 157 tests, no failures from this change.
- Verified on a live two-node setup: restoring an `awg2` protocol backup now completes instead of failing on `cp`, and a container created before AmneziaDNS is actually attached to `amnezia-dns-net` afterwards.

**Note on CI:** the one error in the suite on this branch is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, which has had `main` red since v1.6.4. It is unrelated to this change and fixed in #142.