### PR TITLE
fix: five defects in the v1.6.4 rename, import, PWA and test code

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,6 +113,9 @@ DATA_FILE = os.path.abspath(os.path.expanduser(
     os.environ.get('DATA_FILE') or os.path.join(application_path, 'data.json')
 ))
 CURRENT_VERSION = "v1.6.4"
+
+# Custom protocol instance names: the rename modal caps input at 64 chars.
+CUSTOM_PROTOCOL_NAME_MAX = 64
 BIN_DIR = os.environ.get('TUNNEL_BIN_DIR', os.path.join(application_path, 'bin'))
 TUNNEL_STATE_FILE = os.environ.get('TUNNEL_STATE_FILE', os.path.join(application_path, 'tunnels_state.json'))
 
@@ -3981,7 +3984,9 @@ async def api_rename_protocol(request: Request, server_id: int, req: RenameProto
         proto = req.protocol.strip()
         if proto not in server.get('protocols', {}):
             return JSONResponse({'error': 'Protocol not found'}, status_code=404)
-        name = req.name.strip()
+        # The modal caps input at 64 chars; the API has to cap it too, or a
+        # direct call parks an unbounded string in data.json forever.
+        name = req.name.strip()[:CUSTOM_PROTOCOL_NAME_MAX]
         if name:
             server['protocols'][proto]['custom_name'] = name
         else:
@@ -4049,19 +4054,6 @@ async def api_wgeasy_import(request: Request, server_id: int, req: WgEasyImportR
     except Exception as e:
         logger.exception("Error importing from wg-easy")
         return JSONResponse({'error': str(e), 'log': log}, status_code=500)
-        protocols = server.get('protocols') or {}
-        if req.protocol not in protocols:
-            return JSONResponse({'error': 'Protocol is not installed on this server'}, status_code=404)
-        name = req.name.strip()[:64]
-        if name:
-            protocols[req.protocol]['custom_name'] = name
-        else:
-            protocols[req.protocol].pop('custom_name', None)
-        save_data(data)
-        return {'status': 'success', 'custom_name': name}
-    except Exception as e:
-        logger.exception("Error renaming protocol instance")
-        return JSONResponse({'error': str(e)}, status_code=500)
 
 
 @app.post('/api/servers/{server_id}/server_config/save', tags=["Protocols"])

--- a/static/sw.js
+++ b/static/sw.js
@@ -13,11 +13,17 @@
 const VERSION = new URL(self.location).searchParams.get('v') || 'dev';
 const CACHE = `awp-static-${VERSION}`;
 
+// Every entry has to match the URL the templates actually request, because
+// both fetch branches below match on the exact URL. style.css is requested as
+// ?v={{ static_v }} and the worker itself is registered with the same value,
+// so that one keeps the query; the favicon and the two vendored scripts are
+// requested without it. Freshness still comes from CACHE being named after
+// VERSION - a new version starts an empty cache.
 const PRECACHE = [
   `/static/css/style.css?v=${VERSION}`,
-  `/static/favicon.svg?v=${VERSION}`,
-  `/static/js/qrcode.min.js?v=${VERSION}`,
-  `/static/js/searchable-select.js?v=${VERSION}`,
+  `/static/favicon.svg`,
+  `/static/js/qrcode.min.js`,
+  `/static/js/searchable-select.js`,
   `/static/icons/icon-192.png`,
   `/static/icons/icon-512.png`,
   `/static/icons/maskable-192.png`,

--- a/templates/server.html
+++ b/templates/server.html
@@ -2079,7 +2079,8 @@
             showToast((_('error') || 'Error') + ': ' + err.message, 'error');
         } finally {
             btn.disabled = false;
-            btn.textContent = oldText;
+            // No oldText in this function: it never changes the label, and
+            // referencing an undeclared name threw a ReferenceError on every save.
         }
     }
 

--- a/tests/test_server_template_integrity.py
+++ b/tests/test_server_template_integrity.py
@@ -1,5 +1,6 @@
 """Regression guards for the server-detail page's inline JavaScript and modal markup."""
 import re
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -10,6 +11,7 @@ SERVER_TEMPLATE = ROOT / "templates" / "server.html"
 
 
 class TestServerTemplateIntegrity(unittest.TestCase):
+    @unittest.skipUnless(shutil.which('node'), 'node is not installed')
     def test_rendered_inline_scripts_have_valid_javascript(self):
         """A JS parse error prevents checkServer() from clearing the loading state."""
         import app


### PR DESCRIPTION
## The problem

Five defects that landed with v1.6.4, mostly where #134 (wg-easy import) and #136 (protocol logos and custom names) merged together. All five are in `main` today.

**1. A second `protocol/rename` implementation is buried inside the import handler's `except`** — `app.py` lines 4052-4064. The body sits after `return JSONResponse(...)` inside the wg-easy import handler's `except Exception`, followed by a stray `except Exception` of its own:

```python
    except Exception as e:
        logger.exception("Error importing from wg-easy")
        return JSONResponse({'error': str(e), 'log': log}, status_code=500)
        protocols = server.get('protocols') or {}          # <- unreachable from here down
        ...
    except Exception as e:
        logger.exception("Error renaming protocol instance")
```

Unreachable, so nothing misbehaves — the surviving handler is the earlier `api_rename_protocol` — but it makes the import endpoint's control flow read wrong, and it is what hid defect 2.

**2. The name cap was lost with that dead copy.** The dead version truncated (`req.name.strip()[:64]`); the live handler stores `req.name.strip()` as-is. The rename modal caps input at 64 characters, so the UI never exceeds it — but a direct API call parks an unbounded string in `data.json` permanently, and it is then rendered into every page that shows the instance name.

**3. `saveRenameProtocol()` throws a `ReferenceError` on every save** — `templates/server.html`:

```js
        } finally {
            btn.disabled = false;
            btn.textContent = oldText;   // oldText is never declared in this function
        }
```

It fires in both the success and the failure path. Five other functions in the same file use this pattern (`wgeasyPreview`, `saveServerConfig`, `saveNginxSite`, `createProtocolBackup`, `uploadProtocolBackup`) and every one of them declares `oldText`; this is the only one that does not.

**4. `tests/test_server_template_integrity.py` fails the whole suite when node is missing.** It calls `subprocess.run(["node", "--check", ...])` unconditionally, so without node on PATH it raises `FileNotFoundError` instead of skipping. Reproduced with `env PATH=/usr/bin:/bin python -m unittest tests.test_server_template_integrity`.

**5. `static/sw.js` precaches three URLs nobody requests.** Both fetch branches match on the exact URL, and the templates request these three without a query string:

| PRECACHE entry | Template requests | Verdict |
|---|---|---|
| `style.css?v=${VERSION}` | `?v={{ static_v }}` | **matches** — the worker is registered as `/sw.js?v={{ static_v }}`, so `VERSION` is that same value. Left alone. |
| `favicon.svg?v=${VERSION}` | no query | miss — and the icon branch is cache-first on the exact URL, so it misses the versioned entry, fetches the plain one and caches that too. Stored twice. |
| `js/qrcode.min.js?v=${VERSION}` | no query | miss — the JS branch is network-first, so this entry never even serves the offline fallback it exists for. |
| `js/searchable-select.js?v=${VERSION}` | no query | same |

## The fix

Remove the dead block. Restore the cap as `CUSTOM_PROTOCOL_NAME_MAX = 64`, applied in the live handler. Drop the `oldText` line — that function never changes the button label, so there is nothing to restore. Give the template-integrity test the same `skipUnless(shutil.which('node'))` guard `tests/test_template_js.py` uses. Point the three mismatched PRECACHE entries at the plain URLs; freshness is unaffected, since `CACHE` is named `awp-static-${VERSION}` and a new version starts from an empty cache.

## Testing

Against a running panel:

- `POST /api/servers/0/protocol/rename` with a 100-character name now answers with a 64-character name; before it stored all 100.
- `/openapi.json` still lists `protocol/rename`, `wgeasy/preview` and `wgeasy/import` — removing the dead block did not disturb the endpoints around it.
- `env PATH=/usr/bin:/bin python -m unittest tests.test_server_template_integrity` → `OK (skipped=1)`; before: `FileNotFoundError`.
- `python -m unittest discover -s tests` → 152 tests, no failures from these changes.

**Note on CI:** the single error in the suite is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, which has had `main` red since v1.6.4. Unrelated to this PR; fixed in #142.