### PR TITLE
fix(awg): run the host-tuning probe as a privileged script

### DIFF
--- a/managers/awg_manager.py
+++ b/managers/awg_manager.py
@@ -885,7 +885,10 @@ for c in $(docker ps -a --format '{{.Names}}' | grep '^amnezia-awg' | sort); do
   fi
 done
 """
-        out, err, code = self.ssh.run_sudo_command(script, timeout=60)
+        # A multi-line script has to go through run_sudo_script: `sudo <script>`
+        # only elevates its first line, so every `docker` call below would run
+        # unprivileged and the container list would silently come back empty.
+        out, err, code = self.ssh.run_sudo_script(script, timeout=60)
         info = {'host': {}, 'containers': []}
         if code != 0 or not out:
             return info

--- a/tests/test_host_tuning.py
+++ b/tests/test_host_tuning.py
@@ -1,0 +1,57 @@
+import unittest
+
+from managers.awg_manager import AWGManager
+
+
+class FakeSSH:
+    """Records which transport a caller used: a single sudo command only
+    elevates its first line, a script is uploaded and run as a whole."""
+
+    def __init__(self, script_output='', command_output=''):
+        self.script_output = script_output
+        self.command_output = command_output
+        self.calls = []
+
+    def run_sudo_script(self, script, timeout=120):
+        self.calls.append(('script', script))
+        return self.script_output, '', 0
+
+    def run_sudo_command(self, command, timeout=60):
+        self.calls.append(('command', command))
+        return self.command_output, '', 0
+
+
+TUNING_OUTPUT = """HOST_CC=bbr
+HOST_QDISC=fq
+HOST_AWG_MODULE=3.1.20260812
+CT_NAME=amnezia-awg2
+CT_RUNNING=1
+CTK_net.core.rmem_max=26214400
+CT_NAME=amnezia-awg3
+CT_RUNNING=0
+"""
+
+
+class HostTuningTests(unittest.TestCase):
+    def test_reads_containers_through_a_privileged_script(self):
+        ssh = FakeSSH(script_output=TUNING_OUTPUT)
+        info = AWGManager(ssh).get_host_tuning()
+
+        # the whole thing runs as one privileged script, not as `sudo <script>`
+        self.assertEqual([kind for kind, _ in ssh.calls], ['script'])
+        script = ssh.calls[0][1]
+        self.assertIn('HOST_AWG_MODULE=', script)
+        self.assertIn("grep '^amnezia-awg'", script)
+
+        self.assertEqual(info['host']['cc'], 'bbr')
+        self.assertEqual(info['host']['awg_module'], '3.1.20260812')
+        self.assertEqual([(c['name'], c['running']) for c in info['containers']],
+                         [('amnezia-awg2', True), ('amnezia-awg3', False)])
+        self.assertEqual(info['containers'][0]['ct'], {'net.core.rmem_max': '26214400'})
+
+    def test_empty_output_is_not_an_error(self):
+        self.assertEqual(AWGManager(FakeSSH()).get_host_tuning(), {'host': {}, 'containers': []})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

`AWGManager.get_host_tuning()` passes a multi-line script to `run_sudo_command()`, which builds `echo <pw> | sudo -S -p '' <script>`. Shell precedence elevates only the first line — everything after the first newline runs as the unprivileged SSH user.

The `docker ps -a` loop is on line 8 of that script. On hosts where the login user is not in the `docker` group, the container list comes back empty: the Host tuning modal renders the host rows and simply shows no containers. No error anywhere, just missing data.

`run_sudo_script()` is what the rest of the file already uses for exactly this — five call sites in `awg_manager.py` alone, plus `backup_manager`, `telemt_manager` and `wireguard_manager`. It uploads the script and runs the whole thing under sudo. `get_host_tuning()` was the one place that did not.

## The fix

One line: `run_sudo_command` → `run_sudo_script`, with a comment recording why the distinction matters here.

`tests/test_host_tuning.py` drives `get_host_tuning()` through a fake SSH layer that records which transport the caller used and fails if it is not the script one, then asserts the parsed host keys and the running/stopped container list. A future switch back to `run_sudo_command` fails the suite.

## Testing

- `python -m unittest discover -s tests` → 154 tests, no failures from this change.
- Checked on a live host: with the panel logging in as a non-root sudo user, the Host tuning modal listed no containers before the change and lists them after.

**Note on CI:** the single error in the suite is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, red on `main` since v1.6.4. Unrelated; fixed in #142.