### PR TITLE
test: parse the inline template JavaScript and the translation files

### DIFF
--- a/tests/test_template_js.py
+++ b/tests/test_template_js.py
@@ -1,0 +1,82 @@
+"""Syntax check for the JavaScript that lives inside the Jinja templates.
+
+The page tests assert that particular handlers and elements are present, which
+says nothing about the file still parsing: a merge that lands two blocks at the
+same anchor can swallow a closing brace and every one of those assertions still
+passes. `node --check` catches exactly that, so it runs here whenever node is
+available (it is on the CI image; the test skips without it).
+"""
+
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATES = os.path.join(ROOT, 'templates')
+INLINE_SCRIPT_RE = re.compile(r'<script(?![^>]*\bsrc=)[^>]*>(.*?)</script>', re.S)
+
+
+def inline_js(html):
+    """Inline script bodies with the Jinja placeholders neutralised: `{{ x }}`
+    becomes a bare identifier (valid both as a value and inside a string) and
+    `{% ... %}` tags drop out."""
+    js = '\n'.join(INLINE_SCRIPT_RE.findall(html))
+    js = re.sub(r'\{\{.*?\}\}', 'JINJA', js, flags=re.S)
+    return re.sub(r'\{%.*?%\}', '', js, flags=re.S)
+
+
+class TranslationFileTests(unittest.TestCase):
+    """The same class of silent breakage on the data side: merging two branches
+    that both appended keys can drop the comma between the blocks, and a
+    translation file that no longer parses only shows up as raw keys in the UI
+    (the loader logs the error and serves an empty table)."""
+
+    def test_every_translation_file_parses(self):
+        files = sorted(glob.glob(os.path.join(ROOT, 'translations', '*.json')))
+        self.assertGreaterEqual(len(files), 5, f'only found {files}')
+        tables = {}
+        for path in files:
+            name = os.path.basename(path)
+            with open(path, encoding='utf-8') as f:
+                try:
+                    tables[name] = json.load(f)
+                except json.JSONDecodeError as err:
+                    self.fail(f'{name} does not parse: {err}')
+            self.assertGreater(len(tables[name]), 400, f'{name} looks truncated')
+        # english is the fallback every other language is filled from
+        for name, table in tables.items():
+            extra = sorted(set(table) - set(tables['en.json']))
+            self.assertEqual(extra, [], f'{name} has keys en.json does not: {extra}')
+
+
+@unittest.skipUnless(shutil.which('node'), 'node is not installed')
+class TemplateJsSyntaxTests(unittest.TestCase):
+    def test_every_template_script_parses(self):
+        checked = []
+        for path in sorted(glob.glob(os.path.join(TEMPLATES, '*.html'))):
+            with open(path, encoding='utf-8') as f:
+                js = inline_js(f.read())
+            if not js.strip():
+                continue
+            name = os.path.basename(path)
+            checked.append(name)
+            with tempfile.NamedTemporaryFile('w', suffix='.js', delete=False, encoding='utf-8') as tmp:
+                tmp.write(js)
+                tmp_path = tmp.name
+            try:
+                result = subprocess.run(['node', '--check', tmp_path], capture_output=True, text=True)
+            finally:
+                os.unlink(tmp_path)
+            self.assertEqual(result.returncode, 0, f'{name} does not parse:\n{result.stderr}')
+        # the extraction itself must keep working
+        self.assertIn('server.html', checked)
+        self.assertGreaterEqual(len(checked), 5, f'only {checked} carried inline JS')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

Most of the panel's JavaScript lives inline in `templates/*.html`, and every UI string lives in `translations/*.json`. Neither has any coverage:

- A syntax error in a template's `<script>` block does not fail anything. The page just stops working in the browser — no handler bound, no console visible to CI.
- A broken translation file makes the whole panel render raw keys. `load_translations` catches the `JSONDecodeError` and leaves the dictionary empty, so the failure is silent server-side.

The JSON one is the easier trap to fall into. Two branches that both append keys at the end of a translation file merge cleanly and drop the comma that used to terminate the last entry — git has no reason to flag it. The result is a plausible-looking file among 5 files × ~700 keys, and the symptom is English keys showing up in the UI. Both of your open UI branches append to these files, so it is a live risk, not a hypothetical one.

## The fix

`tests/test_template_js.py`, two tests:

1. Extract every `<script>` block without a `src`, strip the Jinja tags (`{{ ... }}` becomes a literal, `{% ... %}` disappears), and run `node --check` over the result. Skips itself when `node` is not on PATH — `ubuntu-latest` has it preinstalled, so CI does run it.
2. `json.loads` every `translations/*.json`.

## Testing

Against the current `main`:

```
test_every_template_script_parses ... ok
test_every_translation_file_parses ... ok
Ran 2 tests in 0.102s — OK
```

Full suite: 154 tests, no failures from this change.

**Note on CI:** the single error in the suite is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, red on `main` since v1.6.4. Unrelated; fixed in #142.