### PR TITLE
fix(ssh): say what happened when a command dies with the transport

### DIFF
--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -163,6 +163,13 @@ class SSHManager:
         with self._exec_lock:
             return self._run_command_locked(command, timeout, _retried)
 
+    @staticmethod
+    def _reason(exc):
+        """Text for an exception that often carries none: paramiko raises bare
+        EOFError/SSHException when the transport dies mid-command, and an empty
+        string travels all the way to the UI as "... failed: "."""
+        return str(exc).strip() or type(exc).__name__
+
     def _run_command_locked(self, command, timeout, _retried):
         self.ensure_connected()
 
@@ -178,10 +185,10 @@ class SSHManager:
                     self.connect()
                 except Exception as ce:
                     logger.error(f"reconnect failed: {ce}")
-                    return "", str(ce), -1
+                    return "", self._reason(ce), -1
                 return self.run_command(command, timeout=timeout, _retried=True)
             logger.error(f"exec failed after retry: {e}")
-            return "", str(e), -1
+            return "", self._reason(e), -1
 
         # Crucial: set timeout on the channel to prevent hanging indefinitely
         stdout.channel.settimeout(timeout)
@@ -193,7 +200,7 @@ class SSHManager:
             err = stderr.read().decode('utf-8', errors='replace').strip()
         except Exception as e:
             logger.error(f"Command timed out or failed to read: {e}")
-            out, err, exit_code = "", str(e), -1
+            out, err, exit_code = "", f"SSH connection lost while running the command ({self._reason(e)})", -1
 
         if exit_code != 0:
             logger.warning(f"Command exited with code {exit_code}: {err}")

--- a/tests/test_ssh_error_text.py
+++ b/tests/test_ssh_error_text.py
@@ -1,0 +1,51 @@
+"""An SSH failure must say what happened.
+
+Paramiko raises bare `EOFError()` / `SSHException()` when the transport dies
+mid-command, and `str(exc)` on those is an empty string. That empty string is
+what the managers interpolate into their failure messages - there are ~30
+`{err}` sites across managers/ - so a dropped connection surfaced as
+"Failed to configure container: " with nothing after the colon.
+"""
+
+import unittest
+from unittest import mock
+
+from managers.ssh_manager import SSHManager
+
+
+class DeadChannel:
+    def settimeout(self, timeout):
+        pass
+
+    def recv_exit_status(self):
+        raise EOFError()          # exactly what a dropped transport raises
+
+
+class DeadStream:
+    def __init__(self):
+        self.channel = DeadChannel()
+
+    def read(self):
+        return b''
+
+
+class ReasonTests(unittest.TestCase):
+    def test_reason_falls_back_to_the_exception_type(self):
+        self.assertEqual(SSHManager._reason(EOFError()), 'EOFError')
+        self.assertEqual(SSHManager._reason(RuntimeError('  ')), 'RuntimeError')
+        self.assertEqual(SSHManager._reason(RuntimeError('boom')), 'boom')
+
+    def test_a_transport_dying_mid_command_is_reported(self):
+        ssh = SSHManager.__new__(SSHManager)
+        ssh.client = mock.Mock()
+        ssh.client.exec_command.return_value = (None, DeadStream(), DeadStream())
+        ssh.ensure_connected = lambda: None
+
+        out, err, code = ssh._run_command_locked('whoami', 10, False)
+        self.assertEqual((out, code), ('', -1))
+        self.assertIn('SSH connection lost', err)
+        self.assertIn('EOFError', err)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

Paramiko raises a bare `EOFError()` / `SSHException()` when the transport goes away mid-command, and `str(exc)` on those is an **empty string**. `run_command` passes it on as the failure reason, and the managers interpolate that reason straight into their messages — there are about 30 `{err}` sites across `managers/`:

```python
raise RuntimeError(f"Failed to configure container: {err}")   # awg_manager.py:1205
```

So a dropped connection surfaces in the UI as `Failed to configure container: ` — nothing after the colon — and in the log as `Command exited with code -1: `. There is nothing to act on, and it reads like a bug in whatever operation was running rather than a lost connection.

I hit this where the panel manages a host that rate-limits SSH (ufw's `limit` on port 22): a burst of connections gets dropped mid-command, and every resulting error message was blank.

## The fix

`SSHManager._reason(exc)` returns `str(exc).strip()` or, when that is empty, the exception type name. Three call sites use it: the two reconnect paths and the stdout/stderr read, where the message is also labelled — `SSH connection lost while running the command (EOFError)`.

Nothing changes when the exception does carry a message.

`tests/test_ssh_error_text.py` covers the helper directly and drives `_run_command_locked` with a channel whose `recv_exit_status` raises `EOFError` — exactly what a dropped transport does — asserting the reported reason names both the condition and the exception type.

## Testing

- `python -m unittest tests.test_ssh_error_text` → 2 tests, OK.
- Full suite: 154 tests, no failures from this change.

**Note on CI:** the single error in the suite is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, red on `main` since v1.6.4. Unrelated; fixed in #142.