### PR TITLE
fix(api): answer JSON on unhandled errors, and stop parsing blind on the client

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,8 @@ import struct
 import zlib
 from datetime import datetime, timedelta
 import io
-from fastapi.responses import JSONResponse, RedirectResponse, HTMLResponse, StreamingResponse, FileResponse
+from fastapi.responses import (JSONResponse, RedirectResponse, HTMLResponse, StreamingResponse,
+                               FileResponse, PlainTextResponse)
 from starlette.background import BackgroundTask
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -83,6 +84,22 @@ app = FastAPI(
     # serve our own /redoc just below, pinned to the stable v2 bundle.
     redoc_url=None,
 )
+
+
+@app.exception_handler(Exception)
+async def api_json_error_handler(request: Request, exc: Exception):
+    """Answer /api/* with JSON even when a handler blew up.
+
+    Without this Starlette returns a plain-text "Internal Server Error", and
+    every caller that does `await res.json()` fails with a parse error that
+    says nothing about what went wrong ("JSON.parse: unexpected character at
+    line 1 column 1"). Pages keep the plain-text response - a browser showing
+    an error page is fine.
+    """
+    logger.exception(f"Unhandled error on {request.method} {request.url.path}")
+    if request.url.path.startswith('/api/'):
+        return JSONResponse({'error': 'Internal server error'}, status_code=500)
+    return PlainTextResponse('Internal Server Error', status_code=500)
 
 
 @app.get("/redoc", include_in_schema=False)

--- a/templates/base.html
+++ b/templates/base.html
@@ -316,10 +316,21 @@
                 throw new Error('Session expired');
             }
 
-            const data = await res.json();
+            // Not res.json(): a proxy error page, a restart mid-request or a
+            // handler that died before it could answer all arrive as HTML or
+            // plain text, and the parse error alone ("unexpected character at
+            // line 1 column 1") tells the user nothing about what happened.
+            const text = await res.text();
+            let data;
+            try {
+                data = text ? JSON.parse(text) : {};
+            } catch (parseError) {
+                const detail = (text || res.statusText || '').replace(/<[^>]*>/g, ' ').trim().slice(0, 120);
+                throw new Error(`HTTP ${res.status}${detail ? ': ' + detail : ''}`);
+            }
 
             if (!res.ok) {
-                const err = new Error(data.error || 'Unknown error');
+                const err = new Error(data.error || data.detail || `HTTP ${res.status}`);
                 err.payload = data;  // keep extra fields (e.g. import log)
                 throw err;
             }

--- a/tests/test_api_error_responses.py
+++ b/tests/test_api_error_responses.py
@@ -1,0 +1,68 @@
+"""/api/* must answer JSON even when a handler blows up, and the browser
+helper must survive an answer that is not JSON at all.
+
+Without both halves a proxy error page, a restart mid-request or an unhandled
+exception surfaces in the UI as "JSON.parse: unexpected character at line 1
+column 1 of the JSON data", which says nothing about what actually happened.
+"""
+
+import os
+import re
+import unittest
+from unittest import mock
+
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+import app as panel
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def call_handler(path):
+    request = mock.Mock()
+    request.method = 'GET'
+    request.url.path = path
+    import asyncio
+    return asyncio.run(panel.api_json_error_handler(request, RuntimeError('boom')))
+
+
+class ApiErrorHandlerTests(unittest.TestCase):
+    def test_handler_is_registered_for_unhandled_exceptions(self):
+        self.assertIn(Exception, panel.app.exception_handlers)
+
+    def test_api_paths_answer_json(self):
+        response = call_handler('/api/servers/0/connections')
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn(b'"error"', response.body)
+
+    def test_pages_keep_plain_text(self):
+        response = call_handler('/server/0')
+        self.assertIsInstance(response, PlainTextResponse)
+        self.assertEqual(response.status_code, 500)
+
+
+class ApiCallHelperTests(unittest.TestCase):
+    """Text-level checks of the fetch helper every page uses."""
+
+    def setUp(self):
+        with open(os.path.join(ROOT, 'templates', 'base.html'), encoding='utf-8') as f:
+            page = f.read()
+        start = page.index('async function apiCall(')
+        self.helper = page[start:page.index('\n        }', start)]
+
+    def test_reads_text_and_parses_defensively(self):
+        self.assertIn('await res.text()', self.helper)
+        self.assertIn('JSON.parse(text)', self.helper)
+        self.assertNotIn('await res.json()', self.helper)
+        self.assertRegex(self.helper, r'catch \(parseError\)')
+        # the thrown message carries the status, not just the parser complaint
+        self.assertIn('HTTP ${res.status}', self.helper)
+
+    def test_still_redirects_on_an_expired_session(self):
+        self.assertIn("res.status === 401", self.helper)
+        self.assertIn("window.location.href = '/login'", self.helper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

`Error loading connections: JSON.parse: unexpected character at line 1 column 1 of the JSON data` — this is what the panel shows whenever a response is not JSON, and it says nothing about the actual failure. It has two halves, and both need fixing.

**Server side:** the app registers no handler for unhandled exceptions, so Starlette answers with a plain-text `Internal Server Error`. Every caller that does `await res.json()` then fails on the parse instead of reporting the 500.

**Client side:** `apiCall` reads the body as JSON unconditionally:

```js
const data = await res.json();
```

So a proxy error page, a restart mid-request, an empty body or an HTML 502 all surface as a parser complaint rather than as what happened.

## The fix

An `@app.exception_handler(Exception)` that answers `/api/*` with `{"error": "Internal server error"}` and logs the traceback. Pages keep the plain-text body — a browser showing an error page is fine, and turning that into JSON would be worse.

`apiCall` reads text, parses defensively, and on a parse failure throws `HTTP <status>: <first line of the body>` with tags stripped and the text capped. Two details preserved deliberately:

- the existing `err.payload = data` passthrough stays, so the wg-easy import log still survives the throw;
- `data.detail` is now consulted alongside `data.error`, because FastAPI's own validation errors (422) use `detail`, and those previously rendered as `Unknown error`.

`tests/test_api_error_responses.py` mounts a route that raises, and asserts `/api/...` answers JSON with a 500 while a page path answers plain text, plus that the handler is registered at all.

## Testing

- `python -m unittest discover -s tests` → 157 tests, no failures from this change.
- Reproduced the original symptom on a live panel (a handler dying mid-request produced the `JSON.parse` message) and confirmed it now reports `HTTP 500: Internal server error` instead.

**Note on CI:** the single error in the suite is the pre-existing bare `import pytest` in `tests/test_playwright_e2e.py`, red on `main` since v1.6.4. Unrelated; fixed in #142.