### PR TITLE
Fix v1.6.5: server page dies on a duplicated script block, plus six defects from the same merges

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,7 +130,8 @@ class CachedStaticFiles(StaticFiles):
     async def get_response(self, path, scope):
         response = await super().get_response(path, scope)
         if response.status_code == 200:
-            fingerprinted = b'v=' in scope.get('query_string', b'')
+            query = urllib.parse.parse_qsl(scope.get('query_string', b'').decode('latin-1'))
+            fingerprinted = any(key == 'v' for key, _value in query)
             response.headers['Cache-Control'] = (
                 'public, max-age=15552000, immutable' if fingerprinted
                 else 'public, max-age=3600, must-revalidate')

--- a/app.py
+++ b/app.py
@@ -5043,10 +5043,10 @@ async def api_update_user(request: Request, user_id: str, req: UpdateUserRequest
             
         if req.username is not None:
             new_name = req.username.strip()
+            lang = request.cookies.get('lang', 'ru')
             if not new_name:
-                return JSONResponse({'error': 'Username must not be empty'}, status_code=400)
+                return JSONResponse({'error': _t('username_empty', lang)}, status_code=400)
             if any(u['username'] == new_name and u['id'] != user_id for u in data.get('users', [])):
-                lang = request.cookies.get('lang', 'ru')
                 return JSONResponse({'error': _t('user_exists', lang)}, status_code=400)
             user['username'] = new_name
         if req.telegramId is not None:

--- a/app.py
+++ b/app.py
@@ -4955,7 +4955,7 @@ async def api_add_user(request: Request, req: AddUserRequest):
         if any(u['username'] == req.username for u in data.get('users', [])):
             return JSONResponse({'error': _t('user_exists', lang)}, status_code=400)
         if req.role not in ('admin', 'support', 'user', 'none'):
-            return JSONResponse({'error': 'Invalid role'}, status_code=400)
+            return JSONResponse({'error': _t('invalid_role', lang)}, status_code=400)
         if req.role != 'none' and not req.password:
             return JSONResponse({'error': _t('password_required_for_role', lang)}, status_code=400)
         new_user = {

--- a/app.py
+++ b/app.py
@@ -120,14 +120,20 @@ app.add_middleware(SessionMiddleware, secret_key=os.environ.get('SECRET_KEY', se
 
 # Mount static files & templates
 class CachedStaticFiles(StaticFiles):
-    """Static assets are fingerprinted with ?v=<static mtime> (see
-    static_version()), so a redeploy changes the URL and busts the cache.
-    That lets us hand the browser a long 180-day cache lifetime."""
+    """Static assets that carry ?v=<static mtime> (see static_version()) change
+    their URL on every redeploy, so they can be cached for 180 days. Assets
+    referenced without that query - the favicon, the icons, qrcode.min.js,
+    searchable-select.js, the vendored CodeMirror and ReDoc bundles - keep the
+    same URL forever, so an immutable lifetime would freeze them in the
+    browser until it expires. Those get an hour and a revalidation instead."""
 
     async def get_response(self, path, scope):
         response = await super().get_response(path, scope)
         if response.status_code == 200:
-            response.headers['Cache-Control'] = 'public, max-age=15552000, immutable'
+            fingerprinted = b'v=' in scope.get('query_string', b'')
+            response.headers['Cache-Control'] = (
+                'public, max-age=15552000, immutable' if fingerprinted
+                else 'public, max-age=3600, must-revalidate')
         return response
 
 app.mount("/static", CachedStaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")

--- a/app.py
+++ b/app.py
@@ -4360,31 +4360,6 @@ async def api_host_tuning(request: Request, server_id: int):
         return JSONResponse({'error': str(e)}, status_code=500)
 
 
-@app.post('/api/servers/{server_id}/protocol/rename', tags=["Protocols"])
-async def api_rename_protocol(request: Request, server_id: int, req: RenameProtocolRequest):
-    """Set or clear a custom display name for an installed protocol instance."""
-    if not _check_admin(request):
-        return JSONResponse({'error': 'Forbidden'}, status_code=403)
-    try:
-        data = load_data()
-        if server_id >= len(data['servers']):
-            return JSONResponse({'error': 'Server not found'}, status_code=404)
-        server = data['servers'][server_id]
-        protocols = server.get('protocols') or {}
-        if req.protocol not in protocols:
-            return JSONResponse({'error': 'Protocol is not installed on this server'}, status_code=404)
-        name = req.name.strip()[:64]
-        if name:
-            protocols[req.protocol]['custom_name'] = name
-        else:
-            protocols[req.protocol].pop('custom_name', None)
-        save_data(data)
-        return {'status': 'success', 'custom_name': name}
-    except Exception as e:
-        logger.exception("Error renaming protocol instance")
-        return JSONResponse({'error': str(e)}, status_code=500)
-
-
 @app.post('/api/servers/{server_id}/wgeasy/preview', tags=["Protocols"])
 async def api_wgeasy_preview(request: Request, server_id: int, req: WgEasyPreviewRequest):
     """Fetch the client list from a wg-easy / amnezia-wg-easy panel running on

--- a/managers/wireguard_manager.py
+++ b/managers/wireguard_manager.py
@@ -433,9 +433,13 @@ tail -f /dev/null
         # Dockerfile included it; cheap no-op when tc already exists.
         body = "command -v tc >/dev/null 2>&1 || apk add --no-cache iproute2 >/dev/null 2>&1\n" + body
         self.ssh.upload_file(body, "/tmp/_wg_tc.sh")
+        # One `sh -c`: run_sudo_command only privileges the head of a chain,
+        # so `docker cp && docker exec` would run the exec unprivileged.
         self.ssh.run_sudo_command(
+            "sh -c '"
             f"docker cp /tmp/_wg_tc.sh {self.CONTAINER_NAME}:/tmp/_wg_tc.sh && "
-            f"docker exec {self.CONTAINER_NAME} bash /tmp/_wg_tc.sh",
+            f"docker exec {self.CONTAINER_NAME} bash /tmp/_wg_tc.sh"
+            "'",
             timeout=60
         )
         self.ssh.run_command("rm -f /tmp/_wg_tc.sh")

--- a/templates/server.html
+++ b/templates/server.html
@@ -3540,10 +3540,13 @@
                 protocol: proto, client_id: clientId, enable: enable,
             });
             showToast(enable ? _('connection_enabled') : _('connection_disabled'), 'success');
-            loadConnections();
+            await loadConnections();
         } catch (err) {
-            restore();
             showToast(_('error') + ': ' + err.message, 'error');
+        } finally {
+            // Also on success: if loadConnections() fails the row it was
+            // supposed to rebuild would stay disabled with a spinning bulb.
+            restore();
         }
     }
 

--- a/templates/server.html
+++ b/templates/server.html
@@ -2211,47 +2211,6 @@
         }
     }
 
-    // ---------- rename protocol instance ----------
-    let renameProtoTarget = null;
-
-    // Pencils live inside .protocol-name and are (re)built on every status
-    // refresh, so one delegated listener covers static and cloned cards.
-    document.addEventListener('click', (e) => {
-        const el = e.target.closest('.proto-rename');
-        if (el && el.dataset.proto) openRenameProtocol(el.dataset.proto);
-    });
-
-    function openRenameProtocol(proto) {
-        renameProtoTarget = proto;
-        document.getElementById('renameProtoInput').value = CUSTOM_PROTO_NAMES[proto] || getProtoTitle(proto);
-        openModal('renameProtoModal');
-    }
-
-    async function saveRenameProtocol() {
-        const proto = renameProtoTarget;
-        if (!proto) return;
-        const name = document.getElementById('renameProtoInput').value.trim();
-        const btn = document.getElementById('renameProtoSaveBtn');
-        btn.disabled = true;
-        try {
-            await apiCall(`/api/servers/${SERVER_ID}/protocol/rename`, 'POST', { protocol: proto, name });
-            if (name) {
-                CUSTOM_PROTO_NAMES[proto] = name;
-            } else {
-                delete CUSTOM_PROTO_NAMES[proto];
-            }
-            closeModal('renameProtoModal');
-            showToast(_('success') || 'Saved', 'success');
-            setTimeout(() => location.reload(), 800);
-        } catch (err) {
-            showToast((_('error') || 'Error') + ': ' + err.message, 'error');
-        } finally {
-            btn.disabled = false;
-            // No oldText in this function: it never changes the label, and
-            // referencing an undeclared name threw a ReferenceError on every save.
-        }
-    }
-
     function renderWgEasyPreview(res) {
         const esc = s => String(s ?? '').replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
         const info = document.getElementById('wgeasyPreviewInfo');

--- a/templates/server.html
+++ b/templates/server.html
@@ -2164,7 +2164,9 @@
             showToast((_('error') || 'Error') + ': ' + err.message, 'error');
         } finally {
             btn.disabled = false;
-            btn.innerHTML = '{{ _("save") }}';
+            // textContent + the runtime helper: a locale whose "save" carries
+            // a quote would break a server-rendered JS string literal.
+            btn.textContent = _('save') || 'Save';
             document.getElementById('renameProtoInput').disabled = false;
         }
     }

--- a/templates/users.html
+++ b/templates/users.html
@@ -69,7 +69,7 @@
             <div class="form-group">
                 <label class="form-label" id="newPasswordLabel">{{ _('password_label') }}</label>
                 <input class="form-input" type="password" id="newPassword" placeholder="••••••••">
-                <div class="form-hint">{{ _('password_optional_no_role') }}</div>
+                <div class="form-hint" id="newPasswordHint">{{ _('password_optional_no_role') }}</div>
             </div>
 
             <div class="form-group">
@@ -691,6 +691,9 @@
         input.required = needsPass;
         document.getElementById('newPasswordLabel').textContent =
             needsPass ? _('password_label') : _('password_label') + ' (' + _('optional') + ')';
+        // The hint only holds for "none"; leaving it up next to a required
+        // field makes the form contradict itself.
+        document.getElementById('newPasswordHint').style.display = needsPass ? 'none' : '';
     }
 
     async function addUser(e) {

--- a/templates/users.html
+++ b/templates/users.html
@@ -679,6 +679,10 @@
             fetchExistingClients();
         }
         updateTelemtOptions('ucProtocol', 'ucTelemtOptions');
+        // The role select starts on "none", where the password is optional;
+        // without this the label claims it is required until the user touches
+        // the dropdown.
+        toggleNewUserPasswordReq();
     });
 
     function toggleNewUserPasswordReq() {

--- a/templates/users.html
+++ b/templates/users.html
@@ -612,6 +612,10 @@
     document.addEventListener('DOMContentLoaded', () => {
         setupDateTimeFields();
         refreshUsersList();
+        // The role select starts on "none", where the password is optional;
+        // without this the label claims it is required until the select fires
+        // a change event.
+        toggleNewUserPasswordReq();
     });
 
     function updateProtocols(serverId, selectId, groupId = null) {
@@ -679,10 +683,6 @@
             fetchExistingClients();
         }
         updateTelemtOptions('ucProtocol', 'ucTelemtOptions');
-        // The role select starts on "none", where the password is optional;
-        // without this the label claims it is required until the user touches
-        // the dropdown.
-        toggleNewUserPasswordReq();
     });
 
     function toggleNewUserPasswordReq() {

--- a/tests/test_host_tuning.py
+++ b/tests/test_host_tuning.py
@@ -27,7 +27,7 @@ HOST_AWG_MODULE=3.1.20260812
 CT_NAME=amnezia-awg2
 CT_RUNNING=1
 CTK_net.core.rmem_max=26214400
-CT_NAME=amnezia-awg3
+CT_NAME=amnezia-exit
 CT_RUNNING=0
 """
 
@@ -41,12 +41,12 @@ class HostTuningTests(unittest.TestCase):
         self.assertEqual([kind for kind, _ in ssh.calls], ['script'])
         script = ssh.calls[0][1]
         self.assertIn('HOST_AWG_MODULE=', script)
-        self.assertIn("grep '^amnezia-awg'", script)
+        self.assertIn("grep -E '^amnezia-(awg|exit)'", script)
 
         self.assertEqual(info['host']['cc'], 'bbr')
         self.assertEqual(info['host']['awg_module'], '3.1.20260812')
         self.assertEqual([(c['name'], c['running']) for c in info['containers']],
-                         [('amnezia-awg2', True), ('amnezia-awg3', False)])
+                         [('amnezia-awg2', True), ('amnezia-exit', False)])
         self.assertEqual(info['containers'][0]['ct'], {'net.core.rmem_max': '26214400'})
 
     def test_empty_output_is_not_an_error(self):

--- a/tests/test_route_uniqueness.py
+++ b/tests/test_route_uniqueness.py
@@ -1,0 +1,26 @@
+"""No two handlers may claim the same path and method.
+
+Starlette matches routes in definition order, so a second registration of the
+same (path, method) is dead code that the OpenAPI schema still advertises. A
+merge produced exactly that for POST /api/servers/{id}/protocol/rename: the
+copy with the length cap never ran.
+"""
+
+import collections
+import unittest
+
+import app as panel
+
+
+class RouteUniquenessTests(unittest.TestCase):
+    def test_every_path_and_method_is_registered_once(self):
+        seen = collections.Counter()
+        for route in panel.app.routes:
+            for method in getattr(route, 'methods', None) or []:
+                seen[(getattr(route, 'path', ''), method)] += 1
+        duplicates = sorted(key for key, count in seen.items() if count > 1)
+        self.assertEqual(duplicates, [], f"duplicate route registrations: {duplicates}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_static_cache.py
+++ b/tests/test_static_cache.py
@@ -31,6 +31,11 @@ class StaticCacheTests(unittest.TestCase):
         self.assertNotIn('immutable', cache_control)
         self.assertIn('must-revalidate', cache_control)
 
+    def test_another_query_is_not_mistaken_for_a_version(self):
+        res = self.client.get('/static/js/qrcode.min.js?rev=1')
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn('immutable', res.headers['cache-control'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_static_cache.py
+++ b/tests/test_static_cache.py
@@ -1,0 +1,36 @@
+"""Only fingerprinted static URLs may be cached forever.
+
+`static_version()` appends ?v=<mtime> to the assets whose URL is built in a
+template, but plenty of them are referenced without it - the favicon, the
+icons, qrcode.min.js, searchable-select.js, the vendored CodeMirror bundles
+and ReDoc. Those keep the same URL across deploys, so an `immutable` lifetime
+would pin the old file in the browser for half a year.
+"""
+
+import unittest
+
+from fastapi.testclient import TestClient
+
+import app as panel
+
+
+class StaticCacheTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.client = TestClient(panel.app)
+
+    def test_fingerprinted_asset_is_immutable(self):
+        res = self.client.get('/static/css/style.css?v=12345')
+        self.assertEqual(res.status_code, 200)
+        self.assertIn('immutable', res.headers['cache-control'])
+
+    def test_plain_asset_is_revalidated(self):
+        res = self.client.get('/static/js/qrcode.min.js')
+        self.assertEqual(res.status_code, 200)
+        cache_control = res.headers['cache-control']
+        self.assertNotIn('immutable', cache_control)
+        self.assertIn('must-revalidate', cache_control)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sudo_command_chains.py
+++ b/tests/test_sudo_command_chains.py
@@ -11,6 +11,7 @@ import unittest
 from managers.backup_manager import BackupManager
 from managers.adguard_manager import AdguardManager
 from managers.dns_manager import DNSManager
+from managers.wireguard_manager import WireGuardManager
 
 
 class RecordingSSH:
@@ -28,6 +29,9 @@ class RecordingSSH:
         return ('Docker version 27.0.3' if 'docker --version' in command else ''), '', 0
 
     def write_file(self, path, content):
+        pass
+
+    def upload_file(self, content, path):
         pass
 
 
@@ -81,6 +85,18 @@ class SudoChainTests(unittest.TestCase):
         ssh = RecordingSSH(code=0)
         AdguardManager(ssh)._ensure_network()
         self.assertTrue(chain_is_wrapped(ssh.commands[0]), ssh.commands[0])
+
+    def test_wireguard_bw_limits_run_the_chain_in_one_shell(self):
+        ssh = RecordingSSH(code=0)
+        manager = WireGuardManager(ssh)
+        manager.check_container_running = lambda: True
+        manager._apply_bw_limits([
+            {'userData': {'maxSpeed': 10, 'clientIp': '10.8.2.2'}},
+        ])
+        execs = [c for c in ssh.commands if 'docker exec' in c and '_wg_tc.sh' in c]
+        self.assertTrue(execs, ssh.commands)
+        for cmd in execs:
+            self.assertTrue(chain_is_wrapped(cmd), cmd)
 
     def test_helper_flags_a_bare_chain(self):
         self.assertFalse(chain_is_wrapped("test -f a && cp a b"))

--- a/translations/en.json
+++ b/translations/en.json
@@ -590,5 +590,6 @@
   "role_none_badge": "No role",
   "password_optional_no_role": "No password needed for the “No role” role",
   "password_required_for_role": "A password is required for the selected role",
-  "username_empty": "Username must not be empty"
+  "username_empty": "Username must not be empty",
+  "invalid_role": "Invalid role"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -589,5 +589,6 @@
   "role_none_desc": "No role — record only, cannot log in",
   "role_none_badge": "No role",
   "password_optional_no_role": "No password needed for the “No role” role",
-  "password_required_for_role": "A password is required for the selected role"
+  "password_required_for_role": "A password is required for the selected role",
+  "username_empty": "Username must not be empty"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -556,5 +556,6 @@
   "role_none_desc": "بدون نقش — فقط رکورد، بدون امکان ورود",
   "role_none_badge": "بدون نقش",
   "password_optional_no_role": "برای نقش «بدون نقش» رمز عبور لازم نیست",
-  "password_required_for_role": "برای نقش انتخاب‌شده رمز عبور الزامی است"
+  "password_required_for_role": "برای نقش انتخاب‌شده رمز عبور الزامی است",
+  "username_empty": "نام کاربری نمی‌تواند خالی باشد"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -557,5 +557,6 @@
   "role_none_badge": "بدون نقش",
   "password_optional_no_role": "برای نقش «بدون نقش» رمز عبور لازم نیست",
   "password_required_for_role": "برای نقش انتخاب‌شده رمز عبور الزامی است",
-  "username_empty": "نام کاربری نمی‌تواند خالی باشد"
+  "username_empty": "نام کاربری نمی‌تواند خالی باشد",
+  "invalid_role": "نقش نامعتبر"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -556,5 +556,6 @@
   "role_none_desc": "Aucun rôle — simple fiche, connexion impossible",
   "role_none_badge": "Aucun rôle",
   "password_optional_no_role": "Aucun mot de passe requis pour le rôle « Aucun rôle »",
-  "password_required_for_role": "Un mot de passe est requis pour le rôle sélectionné"
+  "password_required_for_role": "Un mot de passe est requis pour le rôle sélectionné",
+  "username_empty": "Le nom d'utilisateur ne peut pas être vide"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -557,5 +557,6 @@
   "role_none_badge": "Aucun rôle",
   "password_optional_no_role": "Aucun mot de passe requis pour le rôle « Aucun rôle »",
   "password_required_for_role": "Un mot de passe est requis pour le rôle sélectionné",
-  "username_empty": "Le nom d'utilisateur ne peut pas être vide"
+  "username_empty": "Le nom d'utilisateur ne peut pas être vide",
+  "invalid_role": "Rôle invalide"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -590,5 +590,6 @@
   "role_none_badge": "Без роли",
   "password_optional_no_role": "Для роли «Без роли» пароль не нужен",
   "password_required_for_role": "Для выбранной роли пароль обязателен",
-  "username_empty": "Имя пользователя не может быть пустым"
+  "username_empty": "Имя пользователя не может быть пустым",
+  "invalid_role": "Недопустимая роль"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -589,5 +589,6 @@
   "role_none_desc": "Без роли — только учётная запись, без входа",
   "role_none_badge": "Без роли",
   "password_optional_no_role": "Для роли «Без роли» пароль не нужен",
-  "password_required_for_role": "Для выбранной роли пароль обязателен"
+  "password_required_for_role": "Для выбранной роли пароль обязателен",
+  "username_empty": "Имя пользователя не может быть пустым"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -556,5 +556,6 @@
   "role_none_desc": "无角色 — 仅记录，无法登录",
   "role_none_badge": "无角色",
   "password_optional_no_role": "“无角色”角色无需密码",
-  "password_required_for_role": "所选角色必须设置密码"
+  "password_required_for_role": "所选角色必须设置密码",
+  "username_empty": "用户名不能为空"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -557,5 +557,6 @@
   "role_none_badge": "无角色",
   "password_optional_no_role": "“无角色”角色无需密码",
   "password_required_for_role": "所选角色必须设置密码",
-  "username_empty": "用户名不能为空"
+  "username_empty": "用户名不能为空",
+  "invalid_role": "角色无效"
 }


### PR DESCRIPTION
Fixes #156. Same symptom as #155.

## The problem

`v1.6.5` ships `templates/server.html` with two copies of the rename-protocol block, so `let renameProtoTarget` is declared twice and the browser refuses the whole inline `<script>`:

```
SyntaxError: Identifier 'renameProtoTarget' has already been declared
```

Nothing on the server page runs after that - the page stays on "Checking server services…" forever, no protocol card ever fills in, no button works. Reproduced on a clean install of the current `main`: `typeof saveRenameProtocol` and `typeof toggleConnection` are both `undefined`, and the page still shows the checking banner after 8 s. On this branch the same check returns `function` for both and the banner is gone.

`app.py` carries the same kind of duplicate: `POST /api/servers/{server_id}/protocol/rename` is registered twice. Starlette matches routes in definition order, so the first handler wins and the second - the one that caps the name at `CUSTOM_PROTOCOL_NAME_MAX` - never runs, while `/docs` lists the endpoint twice.

Both duplicates came in with `Merge branch 'main' into feat/ui-polish` (2c28b88) and again with `Merge branch 'main' into feat/users-norole` (f66ba9b); neither the feature branches nor the merges of #149-#151 had them.

The test suite already catches the first one - `python -m unittest discover -s tests` on `main` fails `test_every_template_script_parses` and `test_reads_containers_through_a_privileged_script`.

Reviewing the rest of what landed with #150-#152 turned up five more defects.

## The fix

**The two failing tests**
* Removed the duplicated rename-protocol block, keeping the copy that restores the button label and re-enables the input in its `finally`.
* `tests/test_host_tuning.py` still expected `grep '^amnezia-awg'`; since #145 and #149 the probe greps `^amnezia-(awg|exit)`.

**Duplicate route**
* Kept a single `protocol/rename` handler - the one with the length cap.

**Static caching**
* `CachedStaticFiles` set `max-age=15552000, immutable` on every `/static` response, but only assets built through `static_version()` carry `?v=<mtime>`. The favicon, the icons, `qrcode.min.js`, `searchable-select.js` and the vendored CodeMirror/ReDoc bundles keep one URL forever, so a redeploy cannot reach a browser that has already cached them - for half a year. Immutable is now limited to URLs that actually carry a `v` parameter (parsed, so `?rev=1` does not qualify); everything else gets `max-age=3600, must-revalidate`.

**Privileged chain**
* `WireGuardManager._apply_bw_limits` ran `docker cp ... && docker exec ...` through `run_sudo_command`, which only privileges the head of the chain - the `docker exec` ran as the panel's unprivileged SSH user, so no `tc` was ever installed on a non-root install. Wrapped in one `sh -c`, the pattern #143 established.

**UI**
* `toggleConnection()` restored the client row only in the error path; when `loadConnections()` fails after a successful toggle, the row stays disabled with a spinning bulb. `restore()` moved into `finally`.
* `saveRenameProtocol()` restored the button label from a server-rendered `'{{ _("save") }}'` string literal - a locale whose translation contains a quote would break the script the same way this issue does. Uses the runtime helper and `textContent` now.
* The add-user modal starts on role `none`, where the password is optional, yet the label said "required" and the "optional" hint stayed up for roles that do require one.
* `api_add_user` and `api_update_user` answered hard-coded English `'Invalid role'` / `'Username must not be empty'` next to `_t('user_exists')`. New keys `invalid_role` and `username_empty` in all five translation files.

## Testing

* `python -m unittest discover -s tests`: **265 tests, OK** (1 skipped - Playwright). On `main`: 2 failures.
* New tests: `tests/test_static_cache.py` (immutable only for `?v=`, `?rev=1` excluded), `tests/test_route_uniqueness.py` (fails on any duplicate `(path, method)` - this class of merge damage would have been caught), and a WireGuard case in `tests/test_sudo_command_chains.py`.
* On a live two-host stand (panel connecting over SSH as a non-root user):
  * server page renders and fills in - `saveRenameProtocol`/`toggleConnection` defined, no "Checking server services" banner; the same check on `main` returns `undefined` for both;
  * `Cache-Control` is `max-age=3600, must-revalidate` for `/static/js/qrcode.min.js` and `?rev=1`, `immutable` only with `?v=`;
  * `/openapi.json` lists `protocol/rename` once, and a 100-char rename is stored capped at 64;
  * a peer speed limit of 10 Mbit/s now really lands: `tc class show dev wg0` inside the container shows `class htb 1:101 root rate 10Mbit ceil 10Mbit` (the panel user is not in the `docker` group, so the unwrapped chain could not have done this);
  * the add-user modal shows "Password (Optional)" with the hint for role `none` and "Password" without it for `admin`;
  * exit-node link, handshake and egress probe unaffected.
* No `CURRENT_VERSION` bump.