### PR TITLE
test: restore the exit-node coverage stripped from two suites

### DIFF
--- a/tests/test_ssh_error_text.py
+++ b/tests/test_ssh_error_text.py
@@ -1,15 +1,14 @@
 """An SSH failure must say what happened.
 
 Paramiko raises bare `EOFError()` / `SSHException()` when the transport dies
-mid-command, and `str(exc)` on those is an empty string. That empty string is
-what the managers interpolate into their failure messages - there are ~30
-`{err}` sites across managers/ - so a dropped connection surfaced as
-"Failed to configure container: " with nothing after the colon.
+mid-command; `str(exc)` on those is an empty string, which used to travel all
+the way to the UI as "exit link apply failed: " with nothing after the colon.
 """
 
 import unittest
 from unittest import mock
 
+from managers.awg_manager import AWGManager
 from managers.ssh_manager import SSHManager
 
 
@@ -45,6 +44,37 @@ class ReasonTests(unittest.TestCase):
         self.assertEqual((out, code), ('', -1))
         self.assertIn('SSH connection lost', err)
         self.assertIn('EOFError', err)
+
+
+class ExitLinkMessageTests(unittest.TestCase):
+    """The exit-link paths must not raise a message that ends at the colon."""
+
+    class SSH:
+        def __init__(self):
+            self.uploads = {}
+
+        def upload_file(self, content, path):
+            self.uploads[path] = content
+
+        def run_command(self, command, timeout=60):
+            return '', '', 0
+
+        def run_sudo_command(self, command, timeout=60):
+            if 'for p in ' in command:
+                return '/opt/amnezia/awg/awg0.conf\n', '', 0
+            return '', '', -1        # dropped connection: no output at all
+
+    def test_apply_and_write_report_the_exit_code(self):
+        manager = AWGManager(self.SSH())
+        with self.assertRaises(RuntimeError) as ctx:
+            manager.exit_unlink('awg2')
+        self.assertIn('SSH exit code -1', str(ctx.exception))
+
+        with self.assertRaises(RuntimeError) as ctx:
+            manager.exit_link('awg2', {'transit_ip': '10.9.0.7', 'subnet_cidr': '24', 'exit_public_key': 'K',
+                                       'psk': 'P', 'endpoint_host': '203.0.113.5', 'endpoint_port': '55520',
+                                       'obfuscation': False, 'awg_params': {}})
+        self.assertIn('SSH exit code -1', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/tests/test_sudo_command_chains.py
+++ b/tests/test_sudo_command_chains.py
@@ -78,8 +78,8 @@ class SudoChainTests(unittest.TestCase):
         self.assertTrue(connects, ssh.commands)
         for cmd in connects:
             self.assertTrue(chain_is_wrapped(cmd), cmd)
-        # a representative container is among the ones attached
-        self.assertTrue(any('amnezia-awg2' in c for c in connects), connects)
+        # the exit-node container is among the ones attached
+        self.assertTrue(any('amnezia-exit' in c for c in connects))
 
     def test_adguard_network_creation_runs_the_chain_in_one_shell(self):
         ssh = RecordingSSH(code=0)


### PR DESCRIPTION
## The problem

`tests/test_ssh_error_text.py` and `tests/test_sudo_command_chains.py` arrived with #147 and #143, both opened before the exit node was merged. Their exit-specific halves had to be removed to keep the modules importable against `main` at that time. Since #149 that code is in the tree, so the stripped copies now assert less than the suites were written to assert.

## The fix

* `test_ssh_error_text.py` gains `ExitLinkMessageTests`. An SSH whose privileged call returns `-1` with no output - a transport that died mid-command - must make `AWGManager.exit_link` and `exit_unlink` raise a message that names the exit code. Without it the empty `str(EOFError())` travelled to the UI as `exit link apply failed: ` with nothing after the colon, which is the failure #147 was about; nothing currently guards the exit-link half of it.
* `test_sudo_command_chains.py` pins `amnezia-exit` instead of `amnezia-awg2` as the container `DNSManager` attaches to `amnezia-dns-net`. Both are in `vpn_containers`, so both assertions pass, but only the exit one catches the case that matters: if the exit container falls out of that list, DNS on an exit node breaks silently while every other protocol keeps working.

No production code changes - two test files, +36/-6.

## Testing

`python -m unittest discover -s tests` on this branch: **266 tests, OK** (1 skipped - Playwright).