### PR TITLE
fix(ssh): feed the sudo password via channel stdin, never the command line

### DIFF
--- a/managers/ssh_manager.py
+++ b/managers/ssh_manager.py
@@ -158,10 +158,15 @@ class SSHManager:
             raise
         return True
 
-    def run_command(self, command, timeout=60, _retried=False):
-        """Execute command on remote server."""
+    def run_command(self, command, timeout=60, _retried=False, stdin_input=None):
+        """Execute command on remote server.
+
+        stdin_input, when given, is written to the channel's stdin right after
+        exec and the write side is closed (same semantics as a shell pipe).
+        Used to feed the sudo password without putting it on the command line.
+        """
         with self._exec_lock:
-            return self._run_command_locked(command, timeout, _retried)
+            return self._run_command_locked(command, timeout, _retried, stdin_input)
 
     @staticmethod
     def _reason(exc):
@@ -170,7 +175,7 @@ class SSHManager:
         string travels all the way to the UI as "... failed: "."""
         return str(exc).strip() or type(exc).__name__
 
-    def _run_command_locked(self, command, timeout, _retried):
+    def _run_command_locked(self, command, timeout, _retried, stdin_input=None):
         self.ensure_connected()
 
         logger.info(f"Running command: {command[:100]}...")
@@ -186,9 +191,19 @@ class SSHManager:
                 except Exception as ce:
                     logger.error(f"reconnect failed: {ce}")
                     return "", self._reason(ce), -1
-                return self.run_command(command, timeout=timeout, _retried=True)
+                return self.run_command(command, timeout=timeout, _retried=True, stdin_input=stdin_input)
             logger.error(f"exec failed after retry: {e}")
             return "", self._reason(e), -1
+
+        if stdin_input is not None:
+            try:
+                stdin.write(stdin_input)
+                stdin.flush()
+                # Signal EOF so consumers of stdin (e.g. docker exec -i)
+                # behave exactly as with the old `echo ... |` pipe.
+                stdin.channel.shutdown_write()
+            except Exception as e:
+                logger.warning(f"failed to write command stdin: {e}")
 
         # Crucial: set timeout on the channel to prevent hanging indefinitely
         stdout.channel.settimeout(timeout)
@@ -207,16 +222,6 @@ class SSHManager:
 
         return out, err, exit_code
 
-    def _sudo_prefix(self):
-        """Get the sudo command prefix with password handling."""
-        if self._is_root:
-            return ''
-        if self.password:
-            # Use sudo -S to read password from stdin
-            escaped_pass = self.password.replace("'", "'\\''")
-            return f"echo '{escaped_pass}' | sudo -S "
-        return 'sudo '
-
     def run_sudo_command(self, command, timeout=60):
         """
         Execute command with sudo, automatically handling password.
@@ -232,14 +237,14 @@ class SSHManager:
             return self.run_command(clean_cmd, timeout=timeout)
 
         if self.password:
-            escaped_pass = self.password.replace("'", "'\\''")
-            # Pipe password directly to sudo -S, preserving original command quoting
-            # 2>/dev/null on echo suppresses '[sudo] password for...' prompt noise
-            full_cmd = f"echo '{escaped_pass}' | sudo -S -p '' {clean_cmd}"
-        else:
-            full_cmd = f"sudo {clean_cmd}"
+            # Feed the password via channel stdin: keeping it out of the
+            # command line hides it from both the panel log (logged above)
+            # and the remote process list.
+            return self.run_command(
+                f"sudo -S -p '' {clean_cmd}", timeout=timeout,
+                stdin_input=self.password + '\n')
 
-        return self.run_command(full_cmd, timeout=timeout)
+        return self.run_command(f"sudo {clean_cmd}", timeout=timeout)
 
     def run_sudo_script(self, script, timeout=120):
         """
@@ -255,14 +260,13 @@ class SSHManager:
         tmp_script = f"/tmp/_amnz_script_{script_hash}.sh"
         self.upload_file(script, tmp_script)
 
-        # Run with sudo
+        # Run with sudo (password via stdin, never on the command line)
         if self.password:
-            escaped_pass = self.password.replace("'", "'\\''")
-            full_cmd = f"echo '{escaped_pass}' | sudo -S -p '' bash {tmp_script}; rm -f {tmp_script}"
-        else:
-            full_cmd = f"sudo bash {tmp_script}; rm -f {tmp_script}"
+            return self.run_command(
+                f"sudo -S -p '' bash {tmp_script}; rm -f {tmp_script}",
+                timeout=timeout, stdin_input=self.password + '\n')
 
-        return self.run_command(full_cmd, timeout=timeout)
+        return self.run_command(f"sudo bash {tmp_script}; rm -f {tmp_script}", timeout=timeout)
 
     def run_script(self, script, timeout=120):
         """Execute a multi-line script on remote server."""

--- a/tests/test_sudo_password_leak.py
+++ b/tests/test_sudo_password_leak.py
@@ -1,0 +1,124 @@
+"""The sudo password must never reach the log or the remote command line.
+
+Previously run_sudo_command/run_sudo_script wrapped every command as
+`echo '<password>' | sudo -S -p '' <cmd>`, and run_command logged the first
+100 chars of that string on every call -- so the panel journal held the sudo
+password in clear text, and `ps` on the managed host showed it for the life
+of the command. The password now travels through the channel's stdin only.
+"""
+
+import logging
+import threading
+import unittest
+from unittest import mock
+
+from managers.ssh_manager import SSHManager
+
+PASSWORD = "S3cr3t Pa'ss w0rd"
+
+
+class FakeChannel:
+    def __init__(self):
+        self.write_closed = False
+
+    def settimeout(self, timeout):
+        pass
+
+    def recv_exit_status(self):
+        return 0
+
+    def shutdown_write(self):
+        self.write_closed = True
+
+
+class FakeStream:
+    def __init__(self, channel=None):
+        self.channel = channel or FakeChannel()
+
+    def read(self):
+        return b''
+
+
+class FakeStdin(FakeStream):
+    def __init__(self):
+        super().__init__()
+        self.written = []
+
+    def write(self, data):
+        self.written.append(data)
+
+    def flush(self):
+        pass
+
+
+def make_ssh():
+    ssh = SSHManager.__new__(SSHManager)
+    ssh._exec_lock = threading.RLock()
+    ssh._is_root = False
+    ssh.password = PASSWORD
+    ssh.ensure_connected = lambda: None
+    ssh.upload_file = lambda content, path: None
+    ssh.client = mock.Mock()
+    return ssh
+
+
+class SudoPasswordLeakTests(unittest.TestCase):
+    def run_and_capture(self, fn):
+        ssh = make_ssh()
+        stdin = FakeStdin()
+        channel = FakeChannel()
+        ssh.client.exec_command.return_value = (
+            stdin, FakeStream(channel), FakeStream(channel))
+
+        records = []
+
+        class Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        handler = Handler()
+        logger = logging.getLogger('managers.ssh_manager')
+        logger.addHandler(handler)
+        try:
+            fn(ssh)
+        finally:
+            logger.removeHandler(handler)
+        return ssh, stdin, records
+
+    def assert_password_hidden(self, ssh, stdin, records):
+        command = ssh.client.exec_command.call_args[0][0]
+        self.assertNotIn(PASSWORD, command)
+        self.assertTrue(all(PASSWORD not in r for r in records))
+        self.assertEqual(stdin.written, [PASSWORD + '\n'])
+        self.assertTrue(stdin.channel.write_closed)
+
+    def test_sudo_command(self):
+        ssh, stdin, records = self.run_and_capture(
+            lambda s: s.run_sudo_command('docker ps'))
+        self.assert_password_hidden(ssh, stdin, records)
+        command = ssh.client.exec_command.call_args[0][0]
+        self.assertEqual(command, "sudo -S -p '' docker ps")
+
+    def test_sudo_script(self):
+        ssh, stdin, records = self.run_and_capture(
+            lambda s: s.run_sudo_script('echo hi'))
+        self.assert_password_hidden(ssh, stdin, records)
+        command = ssh.client.exec_command.call_args[0][0]
+        self.assertTrue(command.startswith("sudo -S -p '' bash /tmp/"))
+
+    def test_root_login_needs_no_stdin(self):
+        ssh = make_ssh()
+        ssh._is_root = True
+        stdin = FakeStdin()
+        channel = FakeChannel()
+        ssh.client = mock.Mock()
+        ssh.client.exec_command.return_value = (
+            stdin, FakeStream(channel), FakeStream(channel))
+        ssh.run_sudo_command('docker ps')
+        command = ssh.client.exec_command.call_args[0][0]
+        self.assertEqual(command, 'docker ps')
+        self.assertEqual(stdin.written, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #120.

## Problem

Every sudo command was wrapped as `echo '<password>' | sudo -S -p '' <cmd>`, and `run_command` logs the first 100 chars of the command string on every call (`ssh_manager.py:176`). For any non-root (sudo) login this wrote the sudo password to the panel journal in clear text on every command, and `ps` on the managed host showed it for the life of the process. Shell escaping did not help — the password is fully recoverable from the logged string.

## Fix

- `run_command`/`_run_command_locked` accept an optional `stdin_input`, written to the channel right after `exec_command`; the write side is then closed (`shutdown_write`) so stdin consumers (e.g. `docker exec -i`) see the same EOF semantics as the old `echo ... |` pipe.
- `run_sudo_command` and `run_sudo_script` now run `sudo -S -p '' <cmd>` and pass the password via `stdin_input`. The password never appears in the command string, so neither the log vector nor the remote `ps` vector can leak it.
- Removed the dead `_sudo_prefix` helper (no callers).
- Root logins are untouched: they take no sudo prefix and no stdin write.

## Regression test

`tests/test_sudo_password_leak.py` drives `run_sudo_command` / `run_sudo_script` against a fake transport with a captured log handler and asserts:
- the password appears in no log record and not in the executed command string;
- the password is delivered via stdin exactly once (`password + '\n'`), with the write side closed;
- root logins send no stdin at all.

Full suite: 268 tests OK.